### PR TITLE
Python tester timeout changes

### DIFF
--- a/testers/python/client/script.py
+++ b/testers/python/client/script.py
@@ -26,9 +26,9 @@ if __name__ == '__main__':
 
     # The max time to run a single test (defaults to 10 seconds if commented out).
     # SPECS['test_timeout'] = 10
-
-    # The max time to run all tests (defaults to 30 seconds if commented out).
-    # SPECS['global_timeout'] = 30
+    # This timeout may not work in particular cases (e.g. when using the hypothesis package, or with multi-threading),
+    # or you may want to have a specific timeout per test function; in those cases, you can decorate your test function:
+    # @timeout_decorator.timeout(10, use_signals=False)
 
     # The feedback file name (defaults to no feedback file if commented out).
     # SPECS['feedback_file'] = 'feedback_python.txt'

--- a/testers/python/install.sh
+++ b/testers/python/install.sh
@@ -13,7 +13,7 @@ UAMLINK=${TESTERDIR}/uam-git
 echo "[PYTHON] Installing system packages"
 sudo apt-get install python3
 echo "[PYTHON] Downloading latest version of UAM"
-if pushd ${UAMDIR} > /dev/null; then
+if pushd ${UAMDIR} &> /dev/null; then
 	git pull
 	popd > /dev/null
 else

--- a/testers/python/requirements.txt
+++ b/testers/python/requirements.txt
@@ -1,1 +1,2 @@
 testtools
+timeout-decorator

--- a/testers/python/specs.json
+++ b/testers/python/specs.json
@@ -1,6 +1,6 @@
 {
   "path_to_uam": "/path/to/uam",
   "test_timeout": 10,
-  "global_timeout": 30,
+  "global_timeout": 3600,
   "feedback_file": null
 }


### PR DESCRIPTION
 * Increase default global timeout to 1 hour and hide it (to use Markus' native one)
 * Install timeout-decorator by default and add info to the test script