### PR TITLE
Fix timeout: enforce timeout by killing threads that read stderr/stdout

### DIFF
--- a/server/automated_tests_server.rb
+++ b/server/automated_tests_server.rb
@@ -46,8 +46,8 @@ class AutomatedTestsServer
         stdin.close
         # mimic capture3 to read safely and capture each line as it comes so that
         # these threads don't hang or raise an error if we have to kill them early
-        stdout_thread = Thread.new { stdout.each { |line| output << line + $/} }
-        stderr_thread = Thread.new { stderr.each { |line| errors << line + $/} }
+        stdout_thread = Thread.new { stdout.each { |line| output << "#{line}\n" } }
+        stderr_thread = Thread.new { stderr.each { |line| errors << "#{line}\n" } }
         if !thread.join(script['timeout']) # still running, let's kill the process group
           if test_username.nil?
             Process.kill('KILL', -pid)
@@ -56,7 +56,7 @@ class AutomatedTestsServer
           end
           # prepend errors with output up to when the timeout occured
           unless output.empty?
-            errors = ["STDOUT BEFORE TIMEOUT OCCURED:", output, "ERRORS:", errors].join($/)
+            errors = "#{errors}\n\n[TEST RESULTS BEFORE TIMEOUT OCCURED]:\n#{output}"
           end
           # timeout output
           output = "


### PR DESCRIPTION
- also add <marks_total> tag to timeout output