### PR TITLE
xml format: add newline to end of result xml

### DIFF
--- a/server/automated_tests_server.rb
+++ b/server/automated_tests_server.rb
@@ -48,7 +48,7 @@ class AutomatedTestsServer
           stdin.close
           # mimic capture3 to read safely and capture each line as it comes so that
           # these threads don't hang or raise an error if we have to kill them early
-          stdout_thread = Thread.new { stdout.each { |line| output << "#{line}\n" } }
+          stdout_thread = Thread.new { stdout.each_line('</test>') { |line| output << "#{line}" } }
           stderr_thread = Thread.new { stderr.each { |line| errors << "#{line}\n" } }
           if !thread.join(script['timeout']) # still running, let's kill the process group
             if test_username.nil?

--- a/testers/markus_tester.py
+++ b/testers/markus_tester.py
@@ -172,7 +172,8 @@ class MarkusTest:
   <marks_earned>{}</marks_earned>
   <marks_total>{}</marks_total>
   <status>{}</status>
-</test>'''.format(test_name, output_escaped, points_earned, points_total, status.value)
+</test>
+'''.format(test_name, output_escaped, points_earned, points_total, status.value)
 
     def format(self, status, output, points_earned):
         """


### PR DESCRIPTION
Ensures result xml ends with a newline so automated_test_server.rb will reliably process the last line of the result (this may cause xml parsing errors later on otherwise)