### PR TITLE
Harmonize Markus and markus-autotesting defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ testers/uam-git/
 testers/java/uam-git
 testers/python/uam-git
 testers/java/**/*.class
+server/.bundle
+server/vendor
+

--- a/install.sh
+++ b/install.sh
@@ -7,11 +7,11 @@ install_packages() {
 
 create_server_user() {
     if [[ -z ${SERVERUSER} ]]; then
-        echo "[AUTOTEST] Not creating any server user"
+        echo "[AUTOTEST] No dedicated server user, using '${THISUSER}'"
         mkdir -p ${WORKINGDIR}
     else
         if id ${SERVERUSER} &> /dev/null; then
-            echo "[AUTOTEST] Reusing existing server user '${SERVERUSER}'"
+            echo "[AUTOTEST] Using existing server user '${SERVERUSER}'"
         else
             echo "[AUTOTEST] Creating server user '${SERVERUSER}'"
             sudo adduser --disabled-password ${SERVERUSER}
@@ -21,61 +21,54 @@ create_server_user() {
     fi
 }
 
-create_default_test_dir() {
-    local testdir=${WORKINGDIR}/${QUEUE}
-    local user=$(whoami)
+create_default_tester_dir() {
+    local testerdir=${WORKINGDIR}/${QUEUE}
 
-    echo "[AUTOTEST] Not creating any test user"
-    sudo mkdir ${testdir}
-    sudo chown ${user}:${user} ${testdir}
-    sudo chmod ug=rwx,o=,+t ${testdir}
-    CONF="${CONF}{user: nil, dir: '${testdir}', queue: '${QUEUE}'},"
+    echo "[AUTOTEST] No dedicated tester user, using '${SERVERUSER2}'"
+    sudo mkdir -p ${testerdir}
+    sudo chown ${SERVERUSER2}:${SERVERUSER2} ${testerdir}
+    sudo chmod ug=rwx,o=,+t ${testerdir}
+    CONF="${CONF}{user: nil, dir: '${testerdir}', queue: '${QUEUE}'},"
 }
 
-create_test_user() {
-    local testuser=$1
-    local queue=$2
-    local testdir=${WORKINGDIR}/${testuser}
+create_tester_user() {
+    local testeruser=$1
+    local testerdir=${WORKINGDIR}/${testeruser}
 
-    if id ${testuser} &> /dev/null; then
-        echo "[AUTOTEST] Reusing existing test user '${testuser}'"
+    if id ${testeruser} &> /dev/null; then
+        echo "[AUTOTEST] Reusing existing tester user '${testeruser}'"
     else
-        echo "[AUTOTEST] Creating test user '${testuser}'"
-        sudo adduser --disabled-login --no-create-home ${testuser}
+        echo "[AUTOTEST] Creating tester user '${testeruser}'"
+        sudo adduser --disabled-login --no-create-home ${testeruser}
     fi
-    sudo mkdir ${testdir}
-    sudo chown ${SERVERUSER}:${testuser} ${testdir}
-    sudo chmod ug=rwx,o=,+t ${testdir}
-    echo "${SERVERUSER} ALL=(${testuser}) NOPASSWD:ALL" | sudo EDITOR="tee -a" visudo
-    CONF="${CONF}{user: '${testuser}', dir: '${testdir}', queue: '${queue}'},"
+    sudo mkdir -p ${testerdir}
+    sudo chown ${SERVERUSER2}:${testeruser} ${testerdir}
+    sudo chmod ug=rwx,o=,+t ${testerdir}
+    echo "${SERVERUSER2} ALL=(${testeruser}) NOPASSWD:ALL" | sudo EDITOR="tee -a" visudo
+    CONF="${CONF}{user: '${testeruser}', dir: '${testerdir}', queue: '${testeruser}'},"
 }
 
-create_test_users() {
-    if [[ -z ${TESTUSER} ]]; then
-        create_default_test_dir
+create_tester_users() {
+    if [[ -z ${TESTERUSER} ]]; then
+        create_default_tester_dir
     else
         if [[ -z ${NUMWORKERS} ]]; then
-            create_test_user ${TESTUSER} ${QUEUE}
+            create_tester_user ${TESTERUSER}
         else
             for i in $(seq 0 $((NUMWORKERS - 1))); do
-                create_test_user ${TESTUSER}${i} ${QUEUE}${i}
+                create_tester_user ${TESTERUSER}${i}
             done
         fi
     fi
 }
 
 create_working_dirs() {
-    local user=${SERVERUSER}
-
     echo "[AUTOTEST] Creating working directories"
-    if [[ -z ${user} ]]; then
-        user=$(whoami)
-    fi
-    sudo mkdir ${SPECSDIR}
-    sudo mkdir ${VENVSDIR}
-    sudo mkdir ${RESULTSDIR}
+    sudo mkdir -p ${SPECSDIR}
+    sudo mkdir -p ${VENVSDIR}
+    sudo mkdir -p ${RESULTSDIR}
     sudo chmod u=rwx,go= ${RESULTSDIR}
-    sudo chown ${user}:${user} ${SPECSDIR} ${VENVSDIR} ${RESULTSDIR}
+    sudo chown ${SERVERUSER2}:${SERVERUSER2} ${SPECSDIR} ${VENVSDIR} ${RESULTSDIR}
 }
 
 install_gems() {
@@ -87,22 +80,22 @@ install_gems() {
 
 run_resque() {
     local cmd="${SERVERDIR}/start_resque.sh ${QUEUE} ${NUMWORKERS}"
-
     if [[ -n ${SERVERUSER} ]]; then
         cmd="sudo -u ${SERVERUSER} -- ${cmd}"
     fi
+
     ${cmd}
 }
 
 create_markus_conf() {
-    local user=""
+    local serverconf=""
+    if [[ -n ${SERVERUSER} ]]; then
+        serverconf="'${SERVERUSER}'"
+    else
+        serverconf="nil"
+    fi
 
     echo "[AUTOTEST] Creating Markus web server config snippet in 'markus_conf.rb'"
-    if [[ -z ${SERVERUSER} ]]; then
-        user=nil
-    else
-        user="'${SERVERUSER}'"
-    fi
     echo "
         AUTOTEST_ON = true
         AUTOTEST_STUDENT_TESTS_ON = false
@@ -110,7 +103,7 @@ create_markus_conf() {
         AUTOTEST_CLIENT_DIR = 'TODO_web_server_dir'
         AUTOTEST_RUN_QUEUE = 'TODO_web_server_queue'
         AUTOTEST_SERVER_HOST = '$(hostname).$(dnsdomainname)'
-        AUTOTEST_SERVER_FILES_USERNAME = ${user}
+        AUTOTEST_SERVER_FILES_USERNAME = ${serverconf}
         AUTOTEST_SERVER_FILES_DIR = '${WORKINGDIR}'
         AUTOTEST_SERVER_RESULTS_DIR = '${RESULTSDIR}'
         AUTOTEST_SERVER_TESTS = [${CONF}]
@@ -118,46 +111,91 @@ create_markus_conf() {
 }
 
 suggest_next_steps() {
-    local user=${SERVERUSER}
-
-    if [[ -z ${user} ]]; then
-        user=$(whoami)
-    else
-        echo "[AUTOTEST] (You must add the Markus web server public key to ${SERVERUSER}'s '~/.ssh/authorized_keys')"
+    if [[ -n ${SERVERUSER} ]]; then
+        echo "[AUTOTEST] (You must add MarkUs web server's public key to ${SERVERUSER}'s '~/.ssh/authorized_keys')"
     fi
-    echo "[AUTOTEST] (You may want to add '${SERVERDIR}/start_resque.sh ${QUEUE} ${NUMWORKERS}' to ${user}'s crontab with a @reboot time)"
+    echo "[AUTOTEST] (You may want to add '${SERVERDIR}/start_resque.sh ${QUEUE} ${NUMWORKERS}' to ${SERVERUSER2}'s crontab with a @reboot time)"
     echo "[AUTOTEST] (You should install the individual testers you plan to use)"
 }
 
+# There are subtleties about THISUSER (X), SERVERUSER (S) and TESTERUSER (T).
+# 1) S and T unspecified:
+#      X is used for S and T, tester dir and queue have a default name, NUMWORKERS ignored
+#      MarkUs conf: local copy of student files + student code execution as X
+# 2) S specified, T unspecified:
+#      S is used for S and T, tester dir and queue have a default name, NUMWORKERS ignored
+#      MarkUs conf: authenticated scp copy of student files + student code execution as S
+# 3) S unspecified, T specified:
+#      X is used for S, T is used, tester dir and queue are named T, NUMWORKERS = n changes T to T0..Tn-1
+#      MarkUs conf: local copy of student files + student code execution as sudo -u T (from X)
+# 4) S and T specified and equals:
+#      same as #2;
+# 5) S and T specified and different:
+#      S and T are used, tester dir and queue are named T, NUMWORKERS = n changes T to T0..Tn-1
+#      MarkUs conf: authenticated scp copy of student files + student code execution as sudo -u T (from S)
+# NOTE: X can be == S|T, but it is different than leaving S|T unspecified
+print_usage() {
+    echo "Usage: $0 working_dir [-s|--server <server_user>] [-t|--tester <tester_user>] [-w|--workers <num_workers>] [-h|--help]"
+}
+
 # script starts here
-if [[ $# -lt 1 || $# -gt 4 ]]; then
-    echo "Usage: $0 working_dir [server_user] [test_user] [num_workers]"
+SHORT=s:t:w:h
+LONG=server:,tester:,workers:,help
+PARSED=$(getopt -o ${SHORT} -l ${LONG} -n "$0" -- "$@")
+if [[ $? -ne 0 ]]; then
+    print_usage
     exit 1
 fi
-
+eval set -- "${PARSED}"
 # vars
 THISSCRIPT=$(readlink -f ${BASH_SOURCE})
 THISSCRIPTDIR=$(dirname ${THISSCRIPT})
-QUEUE=tester # default queue used with no test user, otherwise QUEUE == TESTUSER
+THISUSER=$(whoami)
+NUMWORKERS=""
+SERVERUSER=""
+TESTERUSER=""
+QUEUE=tester # default queue, otherwise QUEUE == TESTERUSER
+while true; do
+    case "$1" in
+        -s | --server )
+            SERVERUSER=$2
+            shift 2
+            ;;
+        -t | --tester )
+            if [[ $2 != ${SERVERUSER} ]]; then
+                TESTERUSER=$2
+                QUEUE=${TESTERUSER}
+            fi
+            shift 2
+            ;;
+        -w | --workers )
+            if [[ -n ${TESTERUSER} ]]; then
+                NUMWORKERS=$2 # option valid only together with -t|--tester
+            fi
+            shift 2
+            ;;
+        -h | --help )
+            print_usage
+            exit
+            ;;
+        -- )
+            shift
+            break
+            ;;
+        * )
+            print_usage
+            exit 1
+    esac
+done
+if [[ $# -ne 1 ]]; then
+    print_usage
+    exit 1
+fi
 WORKINGDIR=$(readlink -f $1)
-if [[ $# -eq 1 ]]; then
-    SERVERUSER=""
-    TESTUSER=""
-    NUMWORKERS=""
-elif [[ $# -eq 2 ]]; then
-    SERVERUSER=$2
-    TESTUSER=""
-    NUMWORKERS=""
-elif [[ $# -eq 3 ]]; then
-    SERVERUSER=$2
-    TESTUSER=$3
-    NUMWORKERS=""
-    QUEUE=${TESTUSER}
+if [[ -n ${SERVERUSER} ]]; then
+    SERVERUSER2=${SERVERUSER}
 else
-    SERVERUSER=$2
-    TESTUSER=$3
-    NUMWORKERS=$4
-    QUEUE=${TESTUSER}
+    SERVERUSER2=${THISUSER}
 fi
 SERVERDIR=${THISSCRIPTDIR}/server
 SPECSDIR=${WORKINGDIR}/specs
@@ -165,12 +203,10 @@ VENVSDIR=${WORKINGDIR}/venvs
 RESULTSDIR=${WORKINGDIR}/results
 CONF=""
 
-#TODO handle default test user with server user
-#TODO allow test user but not server user
 # main
 install_packages
 create_server_user
-create_test_users
+create_tester_users
 create_working_dirs
 install_gems
 run_resque

--- a/install.sh
+++ b/install.sh
@@ -118,22 +118,6 @@ suggest_next_steps() {
     echo "[AUTOTEST] (You should install the individual testers you plan to use)"
 }
 
-# There are subtleties about THISUSER (X), SERVERUSER (S) and TESTERUSER (T).
-# 1) S and T unspecified:
-#      X is used for S and T, tester dir and queue have a default name, NUMWORKERS ignored
-#      MarkUs conf: local copy of student files + student code execution as X
-# 2) S specified, T unspecified:
-#      S is used for S and T, tester dir and queue have a default name, NUMWORKERS ignored
-#      MarkUs conf: authenticated scp copy of student files + student code execution as S
-# 3) S unspecified, T specified:
-#      X is used for S, T is used, tester dir and queue are named T, NUMWORKERS = n changes T to T0..Tn-1
-#      MarkUs conf: local copy of student files + student code execution as sudo -u T (from X)
-# 4) S and T specified and equals:
-#      same as #2;
-# 5) S and T specified and different:
-#      S and T are used, tester dir and queue are named T, NUMWORKERS = n changes T to T0..Tn-1
-#      MarkUs conf: authenticated scp copy of student files + student code execution as sudo -u T (from S)
-# NOTE: X can be == S|T, but it is different than leaving S|T unspecified
 print_usage() {
     echo "Usage: $0 working_dir [-s|--server <server_user>] [-t|--tester <tester_user>] [-w|--workers <num_workers>] [-h|--help]"
 }

--- a/install.sh
+++ b/install.sh
@@ -147,6 +147,7 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 eval set -- "${PARSED}"
+
 # vars
 THISSCRIPT=$(readlink -f ${BASH_SOURCE})
 THISSCRIPTDIR=$(dirname ${THISSCRIPT})

--- a/server/start_resque.sh
+++ b/server/start_resque.sh
@@ -1,14 +1,5 @@
 #!/usr/bin/env bash
 
-kill_workers() {
-    local workers=$(pgrep -f "resque.*${QUEUE}")
-
-    if [[ ! -z ${workers} ]]; then
-        echo "[RESQUE] Killing existing Resque workers"
-        kill -QUIT ${workers}
-    fi
-}
-
 run_worker() {
     local queue=$1
 
@@ -46,5 +37,5 @@ else
 fi
 
 # main
-kill_workers
+${THISSCRIPTDIR}/stop_resque.sh ${QUEUE}
 run_workers

--- a/server/stop_resque.sh
+++ b/server/stop_resque.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+kill_workers() {
+    local workers=$(pgrep -f "resque.*${QUEUE}")
+
+    if [[ ! -z ${workers} ]]; then
+        echo "[RESQUE] Killing existing Resque workers on queue '${QUEUE}'"
+        kill -QUIT ${workers}
+    fi
+}
+
+# script starts here
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "Usage: $0 queue_name"
+    exit 1
+fi
+
+# vars
+THISSCRIPT=$(readlink -f ${BASH_SOURCE})
+THISSCRIPTDIR=$(dirname ${THISSCRIPT})
+QUEUE=$1
+
+# main
+kill_workers


### PR DESCRIPTION
This is the markus-autotesting side of harmonizing a default installation of Markus+markus-autotesting.
(see MarkUsProject/Markus#3336)

The installation can now work for all environments (dev|test|prod) and travis-ci builds.