### PR TITLE
rq: Update install.sh to use .profile

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ write_markus_profile() {
     sudo echo '[[ ":$PATH:" != *"'${SERVERDIR}':"* ]] && export PATH="'${SERVERDIR}':${PATH}"' >> $profile
     sudo echo "supervisord -c ${THISSCRIPTDIR}/supervisord.conf" >> $profile
     sudo echo "source $profile &> /dev/null" >> $serverhome/.bashrc 
-    sudo echo "source $profile &> /dev/null" >> $serverhome/.bash_profile
+    sudo echo "source $profile &> /dev/null" >> $serverhome/.profile
 }
 
 install_venv() {


### PR DESCRIPTION
This makes the script consistent with the Vagrant provisioning scripts on MarkUs.

Turns out if `.bash_profile` exists, `.profile` won't execute. If @adisandro/@mishaschwartz really want to use `.bash_profile` for your own environments, I can change the MarkUs provisioning scripts instead, but I'm merging this in for now.