### PR TITLE
Kill student code more securely

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,9 +43,11 @@ create_user() {
         echo "[AUTOTEST] Creating ${usertype} user '${username}'"
         sudo adduser --disabled-login --no-create-home ${username}
     fi
-    if [[ $(id -gn ${username}) -ne ${groupname} ]]; then
+    if [[ $(id -gn ${username}) != ${groupname} ]]; then
         echo "[AUTOTEST] Changing primary group for '${username}' to '${groupname}'"
         sudo usermod -g ${groupname} ${username}
+    else
+        echo "[AUTOTEST] Primary group of '${username}' is '${groupname}'"
     fi
     echo "${SERVERUSEREFFECTIVE} ALL=(${username}) NOPASSWD:ALL" | sudo EDITOR="tee -a" visudo
 }

--- a/server/autotest_server.py
+++ b/server/autotest_server.py
@@ -453,7 +453,9 @@ def clean_up_tests(tests_path, test_username):
     
     subprocess.run(chmod_cmd, shell=True)
     
-    clean_cmd = 'rm -rf {}'.format(tests_path)
+    # be careful not to remove the tests_path dir itself since we have to 
+    # set the group ownership with sudo (and that is only done in ../install.sh)
+    clean_cmd = 'rm -rf {}/*'.format(tests_path)
     subprocess.run(clean_cmd, shell=True)
 
 

--- a/server/config.py
+++ b/server/config.py
@@ -46,6 +46,10 @@ REAPER_USER_PREFIX = ''
 
 # values are: (soft limit, hard limit)
 # see https://docs.python.org/3/library/resource.html for reference on limit options
+# NOTE: these limits cannot be higher than the limits set for the tester user in 
+#       /etc/security/limits.conf (or similar). These limits may be reduced in certain 
+#       cases (see the docstring for get_test_preexec_fn and get_cleanup_preexec_fn in 
+#       autotest_server.py)
 RLIMIT_SETTINGS = {
     'RLIMIT_NPROC': (300, 300)
 }

--- a/server/config.py
+++ b/server/config.py
@@ -38,6 +38,9 @@ WORKERS_DIR_NAME = 'workers'
 SERVER_USER = ''
 # names of the tester users
 WORKER_USERS = ''
+# prefix used to name reaper users 
+# (reapers not used to kill worker processes if set to the empty string)
+REAPER_USER_PREFIX = ''
 
 
 ### QUEUE CONFIGS ###

--- a/server/config.py
+++ b/server/config.py
@@ -42,6 +42,13 @@ WORKER_USERS = ''
 # (reapers not used to kill worker processes if set to the empty string)
 REAPER_USER_PREFIX = ''
 
+## RLIMIT SETTINGS FOR TESTER PROCESSES ##
+
+# values are: (soft limit, hard limit)
+# see https://docs.python.org/3/library/resource.html for reference on limit options
+RLIMIT_SETTINGS = {
+    'RLIMIT_NPROC': (300, 300)
+}
 
 ### QUEUE CONFIGS ###
 

--- a/server/kill_worker_procs.c
+++ b/server/kill_worker_procs.c
@@ -1,0 +1,17 @@
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <signal.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[])
+{
+	remove(argv[0]);
+	uid_t reaper_uid = getuid();
+	uid_t worker_uid = geteuid();
+	if ( setresuid(reaper_uid, worker_uid, reaper_uid) < 0 ) 
+	{
+		return -1;
+	}
+	kill(-1, SIGKILL);
+	return 0;
+}


### PR DESCRIPTION
This is an attempt to implement the strategy for killing potentially malicious code described in this article: https://lwn.net/Articles/754980/

* for every tester user, we now also create a reaper user whose sole job is to kill the tester user's processes
* these processes are killed using the `kill_worker_procs` executable (compiled at install time and copied for each use). See the article (above) for an explanation on how the various permission settings on this file let us safely kill worker processes
* also introduces a way to set rlimit limits for tester users. These limits are also manipulated to ensure the reaper can always kill the tester's processes. 
* fixes a bug where a tester user could only do a single test run in their working directory before changes to that directory's permissions locked them out.