### PR TITLE
Add ability to move empty directories

### DIFF
--- a/server/autotest_server.py
+++ b/server/autotest_server.py
@@ -149,6 +149,7 @@ def move_tree(src, dst):
     indicated by src to the path indicated by dst. If directories
     don't exist, they are created. 
     """
+    os.makedirs(dst, exist_ok=True)
     copy_tree(src, dst)
     shutil.rmtree(src, onerror=ignore_missing_dir_error)
 

--- a/testers/haskell/specs.json
+++ b/testers/haskell/specs.json
@@ -1,0 +1,5 @@
+{
+  "test_timeout": 10,
+  "global_timeout": 3600,
+  "feedback_file": null
+}


### PR DESCRIPTION
Fixes a bug where empty directories were not moved by the move_tree function. 
Also adds default specs.json to haskell tester that should have been there already but was overlooked