### PR TITLE
fix syntax error in supervisor config file

### DIFF
--- a/server/generate_supervisord_conf.py
+++ b/server/generate_supervisord_conf.py
@@ -19,7 +19,7 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 content = """[program:rq_worker_type{type_ind}]
 command={rq} worker {worker_args} {queues}
-process_name=%(program_name)%(process_num)
+process_name=%(program_name)s-%(process_num)02d
 numprocs={numprocs}
 directory={directory}
 stopsignal=TERM


### PR DESCRIPTION
fix syntax error in supervisord.conf file that was causing supervisor processes not to be created properly