### PR TITLE
Generalize python3 version in shebang

### DIFF
--- a/server/autotest_enqueuer.py
+++ b/server/autotest_enqueuer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 
 import sys
 import argparse

--- a/server/autotest_server.py
+++ b/server/autotest_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 
 import os
 import fcntl


### PR DESCRIPTION
generalize shebang from python3.X to python3 and rely on venv to specify correct python3 version