### PR TITLE
configure GHC_PACKAGE_PATH using specs

### DIFF
--- a/testers/haskell/client/Test.hs
+++ b/testers/haskell/client/Test.hs
@@ -1,5 +1,3 @@
-#!/usr/bin/env runghc
-
 module Test where
 import Test.QuickCheck (Property, (==>))
 import Submission (celsiusToFarenheit, nCopies, numEvens, numManyEvens)

--- a/testers/haskell/client/Test.hs
+++ b/testers/haskell/client/Test.hs
@@ -47,14 +47,14 @@ prop_numManyEvensAgainstReference :: [[Int]] -> Bool
 prop_numManyEvensAgainstReference x = numManyEvens x == Soln.numManyEvens x
 
 
-main :: IO ()
-main = do
-  quickCheck prop_celsius0
-  quickCheck prop_celsius37
-  quickCheck prop_nCopiesLength
-  quickCheck prop_numEvensLength
-  quickCheck prop_numManyEvensDoubled
-  quickCheck prop_celsiusAgainstReference
-  quickCheck prop_nCopiesAgainstReference
-  quickCheck prop_numEvensAgainstReference
-  quickCheck prop_numManyEvensAgainstReference
+-- main :: IO ()
+-- main = do
+  -- quickCheck prop_celsius0
+  -- quickCheck prop_celsius37
+  -- quickCheck prop_nCopiesLength
+  -- quickCheck prop_numEvensLength
+  -- quickCheck prop_numManyEvensDoubled
+  -- quickCheck prop_celsiusAgainstReference
+  -- quickCheck prop_nCopiesAgainstReference
+  -- quickCheck prop_numEvensAgainstReference
+  -- quickCheck prop_numManyEvensAgainstReference

--- a/testers/haskell/install.sh
+++ b/testers/haskell/install.sh
@@ -6,29 +6,23 @@ install_packages() {
 }
 
 install_haskell_packages() {
-    mkdir -p ${PKG_DIR}
     cabal update
     # The order that these packages are installed matters. Could cause a dependency conflict 
     # Crucially it looks like tasty-stats needs to be installed before tasty-quickcheck 
-    cabal install tasty-stats --prefix=${PKG_DIR}/packages
-    cabal install tasty-discover --prefix=${PKG_DIR}/packages
-    cabal install tasty-quickcheck --prefix=${PKG_DIR}/packages
+    sudo cabal install tasty-stats --global
+    sudo cabal install tasty-discover --global
+    sudo cabal install tasty-quickcheck --global
 
     # install additional haskell packages (passed as arguments to this script)
     for package in "$@"; do
-        cabal install $package --prefix=${PKG_DIR}/packages
+        sudo cabal install $package --global
     done
-    mv ${HOME}/.ghc/*/package.conf.d ${PKG_DIR}
 }
 
 if [[ " $@ " =~ " -h " || " $@ " =~ " --help " ]]; then
         echo "Usage: $0 [cabal_packages_to_install ... ]"
         exit 0
 fi
-
-THISSCRIPT=$(readlink -f ${BASH_SOURCE})
-THISSCRIPTDIR=$(dirname ${THISSCRIPT})
-PKG_DIR=${THISSCRIPTDIR}/server/markus_cabal
 
 # main
 install_packages

--- a/testers/haskell/install.sh
+++ b/testers/haskell/install.sh
@@ -6,22 +6,18 @@ install_packages() {
 }
 
 install_haskell_packages() {
-    cabal update
+    sudo cabal update
     # The order that these packages are installed matters. Could cause a dependency conflict 
     # Crucially it looks like tasty-stats needs to be installed before tasty-quickcheck 
     sudo cabal install tasty-stats --global
     sudo cabal install tasty-discover --global
     sudo cabal install tasty-quickcheck --global
-
-    # install additional haskell packages (passed as arguments to this script)
-    for package in "$@"; do
-        sudo cabal install $package --global
-    done
 }
 
-if [[ " $@ " =~ " -h " || " $@ " =~ " --help " ]]; then
-        echo "Usage: $0 [cabal_packages_to_install ... ]"
-        exit 0
+# script starts here
+if [ $# -ne 0 ]; then
+    echo "Usage: $0"
+    exit 1
 fi
 
 # main

--- a/testers/haskell/server/markus_haskell_tester.py
+++ b/testers/haskell/server/markus_haskell_tester.py
@@ -74,8 +74,10 @@ class MarkusHaskellTester(MarkusTester):
 
         GHC_PACKAGE_PATH <- tells the haskell compiler where to find installed packages
         """
-        env_update = {'GHC_PACKAGE_PATH' : self.specs.get('ghc_package_path', '')}
-        return {**os.environ, **env_update}
+        ghc_pkg_pth = self.specs.get('ghc_package_path')
+        if ghc_pkg_pth is not None:
+            return {**os.environ, **{'GHC_PACKAGE_PATH' : ghc_pkg_pth}}
+        return os.environ
 
     def run_haskell_tests(self):
         """

--- a/testers/haskell/server/markus_haskell_tester.py
+++ b/testers/haskell/server/markus_haskell_tester.py
@@ -92,13 +92,15 @@ class MarkusHaskellTester(MarkusTester):
 
             with tempfile.NamedTemporaryFile() as f:
                 cmd = ['tasty-discover', '.', '_', f.name] + self._test_run_flags(test_file)
-                discover_proc = subprocess.run(cmd, stderr=subprocess.PIPE, stdout=subprocess.DEVNULL, universal_newlines=True, env=self._get_haskell_env())
+                discover_proc = subprocess.run(cmd, stderr=subprocess.PIPE, stdout=subprocess.DEVNULL,
+                                               universal_newlines=True, env=self._get_haskell_env())
                 if discover_proc.stderr:
                     print(MarkusTester.error_all(message=discover_proc.stderr), flush=True)
                     continue
                 with tempfile.NamedTemporaryFile(mode="w+") as sf:
                     cmd = ['runghc', f.name, f"--stats={sf.name}"]
-                    test_proc = subprocess.run(cmd, stderr=subprocess.PIPE, stdout=subprocess.DEVNULL, universal_newlines=True, env=self._get_haskell_env())
+                    test_proc = subprocess.run(cmd, stderr=subprocess.PIPE, stdout=subprocess.DEVNULL,
+                                               universal_newlines=True, env=self._get_haskell_env())
                     results[test_file] = {'stderr':test_proc.stderr, 'results':self._parse_test_results(csv.reader(sf))}
         return results
 

--- a/testers/haskell/specs.json
+++ b/testers/haskell/specs.json
@@ -1,5 +1,6 @@
 {
   "test_timeout": 10,
   "global_timeout": 3600,
-  "feedback_file": null
+  "feedback_file": null,
+  "ghc_package_path": ""
 }

--- a/testers/haskell/specs.json
+++ b/testers/haskell/specs.json
@@ -2,5 +2,5 @@
   "test_timeout": 10,
   "global_timeout": 3600,
   "feedback_file": null,
-  "ghc_package_path": ""
+  "ghc_package_path": null
 }


### PR DESCRIPTION
Allows us to configure the GHC_PACKAGE_PATH variable that all haskell test commands use using the specs file. This makes it potentially configurable for each instance separately. 

Updates the haskell install script to install cabal packages globally (probably not best practice in the long run but good enough until we come up with something better)