### PR TITLE
Better error messages in racket tester

### DIFF
--- a/testers/racket/server/markus_racket_tester.py
+++ b/testers/racket/server/markus_racket_tester.py
@@ -35,6 +35,8 @@ class MarkusRacketTest(MarkusTest):
 
 class MarkusRacketTester(MarkusTester):
 
+    ERROR_MSGS = {'bad_json': 'Unable to parse test results: {}'}
+
     def __init__(self, specs, test_class=MarkusRacketTest):
         super().__init__(specs, test_class)
     
@@ -69,7 +71,7 @@ class MarkusRacketTester(MarkusTester):
                         try:
                             test_results = json.loads(result.stdout)
                         except json.JSONDecodeError:
-                            msg = f'Unable to parse test results: {result.stdout}'
+                            msg = MarkusRacketTester.ERROR_MSGS['bad_json'].format(result.stdout)
                             print(MarkusTester.error_all(message=msg), flush=True)
                             continue
                         for t_result in test_results:

--- a/testers/racket/server/markus_racket_tester.py
+++ b/testers/racket/server/markus_racket_tester.py
@@ -65,17 +65,16 @@ class MarkusRacketTester(MarkusTester):
                                  if self.specs.feedback_file is not None
                                  else None)
                 for test_file, result in results.items():
-                    if result.stderr:
-                        print(MarkusTester.error_all(message=result.stderr), flush=True)
-                    try:
-                        test_results = json.loads(result.stdout)
-                    except json.JSONDecodeError:
-                        msg = f'Unable to parse JSON: {result.stdout}'
-                        print(MarkusTester.error_all(message=msg), flush=True)
-                        continue
-                    for t_result in test_results:
-                        test = self.test_class(self, feedback_open, test_file, t_result)
-                        print(test.run(), flush=True)
+                    if result.strip():
+                        try:
+                            test_results = json.loads(result.stdout)
+                        except json.JSONDecodeError:
+                            msg = f'Unable to parse test results: {result.stdout}'
+                            print(MarkusTester.error_all(message=msg), flush=True)
+                            continue
+                        for t_result in test_results:
+                            test = self.test_class(self, feedback_open, test_file, t_result)
+                            print(test.run(), flush=True)
         except Exception as e:
             print(MarkusTester.error_all(message=str(e)), flush=True)
             return


### PR DESCRIPTION
* don't treat any stderr output as a true error
* skip empty stdout instead of raising errors