### PR TITLE
Allow pytest tests to be run using an arbitrary virtual environment

### DIFF
--- a/testers/python/specs.json
+++ b/testers/python/specs.json
@@ -2,5 +2,6 @@
   "path_to_uam": "/path/to/uam",
   "test_timeout": 10,
   "global_timeout": 3600,
-  "feedback_file": null
+  "feedback_file": null,
+  "legacy_virtualenv": null
 }


### PR DESCRIPTION
This allows us to run python tests using an older python version (ie. python2.x)