### PR TITLE
Make python tester verbosity configurable

### DIFF
--- a/testers/python/client/script.py
+++ b/testers/python/client/script.py
@@ -29,6 +29,25 @@ if __name__ == '__main__':
     SPECS['test_points'] = {'test.py': POINTS, 'test2.py': POINTS}
 
     """
+    If using the pytest tester, set the traceback format, options are:
+        'auto', 'long', 'short', 'no', 'line', 'native'
+    The default is 'short' if commented out
+    """
+    # SPECS["pytest_tb_format"] = "short"
+
+    """
+    If using the unittest tester, set the verbosity level, options are: 0, 1, 2
+    The default is 2 if commented out
+    """
+    # SPECS["unittest_verbosity"] = 2
+
+    """
+    Choose which python tester to use, options are: 'pytest', 'unittest'
+    The default is 'pytest' if commented out
+    """
+    # SPECS["tester"] = "pytest"
+
+    """
     The feedback file name; defaults to no feedback file if commented out.
     """
     # SPECS['feedback_file'] = 'feedback_python.txt'

--- a/testers/python/specs.json
+++ b/testers/python/specs.json
@@ -1,4 +1,7 @@
 {
   "feedback_file": null,
-  "legacy_virtualenv": null
+  "legacy_virtualenv": null,
+  "pytest_tb_format": "short",
+  "unittest_verbosity": 2,
+  "tester": "pytest"
 }


### PR DESCRIPTION
* don't do tester discovery 
* allow for configurable test output for unittest and pytest
* added the following spec options for the python tester:
     * [pytest_tb_format](https://pytest.readthedocs.io/en/2.1.0/usage.html#modifying-python-traceback-printing)
     * [unittest_verbosity](https://stackoverflow.com/a/1322648/5992438)
     * tester (either `'pytest'` or `'unittest'`)
