### PR TITLE
Allow long running ltrace tests to return partial results

### DIFF
--- a/testers/python/server/lib/c_helper.py
+++ b/testers/python/server/lib/c_helper.py
@@ -231,7 +231,10 @@ class Trace:
 
     def __init__(self, command: List[str], ltrace_flags: Optional[List[str]] = None, **kwargs):
         ltrace_flags = ltrace_flags or []
-        _exec(['ltrace'] + ltrace_flags + command, **kwargs)
+        try:
+            _exec(['ltrace'] + ltrace_flags + command, **kwargs)
+        except subprocess.TimeoutExpired: # allow for partial results to be reported
+            pass
 
         with open(DEFAULT_LTRACE_LOG_FILE, 'rb') as f:
             f_bytes = f.read()


### PR DESCRIPTION
This change was made in a previous version of this library but did not make it into the version that was added here. 