### PR TITLE
Unpin redis version

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,4 @@
-redis==2.10.6
+redis
 requests
 rq
 git+https://github.com/Supervisor/supervisor@master


### PR DESCRIPTION
unpin redis from version < 3.0 now that rq has updated their code (see https://github.com/rq/rq/pull/1016)