### PR TITLE
Fix bug that occurs when determining which tester to run

### DIFF
--- a/testers/python/server/markus_python_tester.py
+++ b/testers/python/server/markus_python_tester.py
@@ -168,8 +168,7 @@ class MarkusPythonTester(MarkusTester):
         """
         results = {}
         for test_file in self.specs.tests:
-            func = self._detect_test_tool_function(test_file)
-            if specs.get('tester', 'pytest') == 'unittest':
+            if self.specs.get('tester', 'pytest') == 'unittest':
                 result = self._run_unittest_tests(test_file)
             else:
                 result = self._run_pytest_tests(test_file)


### PR DESCRIPTION
This was trying to use a deprecated (and removed) function