### PR TITLE
Autotest future (Part 6): add fixture files for future testing

### DIFF
--- a/testers/testers/haskell/tests/script.py
+++ b/testers/testers/haskell/tests/script.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+from markus_haskell_tester import MarkusHaskellTester
+from markus_tester import MarkusTestSpecs
+
+if __name__ == '__main__':
+
+    SPECS = MarkusTestSpecs()
+
+    '''
+    The test files to run (uploaded as support files), and the points assigned:
+    points can be assigned per test.  If a test is missing, it is assigned a 
+    default of 1 point (use POINTS = {} for all 1s).
+    '''
+    POINTS = {}
+    SPECS['test_points'] = {'Test.hs': POINTS}
+
+    '''
+    The max time to run a single test (defaults to 10 seconds if commented out).
+    (this timeout may not work in particular cases, e.g. with multi-threading)
+    '''
+    
+    # SPECS['test_timeout'] = 10
+
+    '''
+    The number of test cases to run for each quickcheck test 
+    (default is 100)
+    '''
+
+    # SPECS['test_cases'] = 100
+
+    '''
+    The feedback file name (defaults to no feedback file if commented out).
+    '''
+
+    # SPECS['feedback_file'] = 'feedback_haskell.txt'
+
+    tester = MarkusHaskellTester(specs=SPECS)
+    tester.run()

--- a/testers/testers/haskell/tests/script_files/Test.hs
+++ b/testers/testers/haskell/tests/script_files/Test.hs
@@ -1,0 +1,60 @@
+module Test where
+import Test.QuickCheck (Property, (==>))
+import Submission (celsiusToFarenheit, nCopies, numEvens, numManyEvens)
+import qualified Submission as Soln (celsiusToFarenheit, nCopies, numEvens, numManyEvens)
+
+prop_celsius0 :: Bool
+prop_celsius0 =
+    celsiusToFarenheit 0 == 32
+
+prop_celsius37 :: Bool
+prop_celsius37 =
+    celsiusToFarenheit 37 == 99
+
+
+prop_nCopiesLength :: [Char] -> Int -> Property
+prop_nCopiesLength s n =
+    n >= 0 ==> (length (nCopies s n) == (length s) * n)
+
+
+prop_numEvensLength :: [Int] -> Bool
+prop_numEvensLength nums =
+    numEvens nums <= length nums
+
+
+-- | What do you think this property says?
+prop_numManyEvensDoubled :: [[Int]] -> Bool
+prop_numManyEvensDoubled listsOfNums =
+    let doubled = listsOfNums ++ listsOfNums
+    in
+        numManyEvens doubled == 2 * (numManyEvens listsOfNums)
+
+
+prop_celsiusAgainstReference :: Float -> Bool
+prop_celsiusAgainstReference x = celsiusToFarenheit x == Soln.celsiusToFarenheit x
+
+
+prop_nCopiesAgainstReference :: [Char] -> Int -> Property
+prop_nCopiesAgainstReference s x =
+    x >= 0 ==> nCopies s x == Soln.nCopies s x
+
+
+prop_numEvensAgainstReference :: [Int] -> Bool
+prop_numEvensAgainstReference x = numEvens x == Soln.numEvens x
+
+
+prop_numManyEvensAgainstReference :: [[Int]] -> Bool
+prop_numManyEvensAgainstReference x = numManyEvens x == Soln.numManyEvens x
+
+
+-- main :: IO ()
+-- main = do
+  -- quickCheck prop_celsius0
+  -- quickCheck prop_celsius37
+  -- quickCheck prop_nCopiesLength
+  -- quickCheck prop_numEvensLength
+  -- quickCheck prop_numManyEvensDoubled
+  -- quickCheck prop_celsiusAgainstReference
+  -- quickCheck prop_nCopiesAgainstReference
+  -- quickCheck prop_numEvensAgainstReference
+  -- quickCheck prop_numManyEvensAgainstReference

--- a/testers/testers/haskell/tests/specs.json
+++ b/testers/testers/haskell/tests/specs.json
@@ -1,0 +1,10 @@
+{
+  "test_timeout": 10,
+  "test_cases": 100,
+  "feedback_file": null,
+  "enable_feedback_file_hook": false,
+  "hooks": null,
+  "script_files": [],
+  "support_files": [],
+  "points": {}
+}

--- a/testers/testers/haskell/tests/student_files/Submission.hs
+++ b/testers/testers/haskell/tests/student_files/Submission.hs
@@ -1,0 +1,81 @@
+
+module Submission (celsiusToFarenheit, nCopies, numEvens, numManyEvens) where
+
+import Test.QuickCheck (Property, quickCheck, (==>))
+
+
+celsiusToFarenheit :: Float -> Int
+celsiusToFarenheit temp =
+    32 + round ((9.0/5.0) * temp)
+
+prop_celsius0 :: Bool
+prop_celsius0 =
+    celsiusToFarenheit 0 == 32
+
+prop_celsius37 :: Bool
+prop_celsius37 =
+    celsiusToFarenheit 37 == 99
+
+-------------------------------------------------------------------------------
+
+
+nCopies :: String -> Int -> String
+nCopies _ 0 = ""
+nCopies s n = s ++ nCopies s (n - 1)
+
+
+prop_nCopiesLength :: [Char] -> Int -> Property
+prop_nCopiesLength s n =
+    n >= 0 ==> (length (nCopies s n) == (length s) * n)
+
+-------------------------------------------------------------------------------
+
+
+numEvens :: [Int] -> Int
+numEvens numbers =
+    if null numbers
+    then
+        0
+    else
+        let firstNumber = head numbers
+            numEvensInRest = numEvens (tail numbers)
+        in
+            if firstNumber `mod` 2 == 0
+            then
+                1 + numEvensInRest
+            else
+                numEvensInRest
+
+
+numManyEvens :: [[Int]] -> Int
+numManyEvens [] = 0
+numManyEvens (firstList : rest) =
+    let numManyEvensInRest = numManyEvens rest
+    in
+        if numEvens firstList >= 3
+        then
+            1 + numManyEvensInRest
+        else
+            numManyEvensInRest
+
+
+prop_numEvensLength :: [Int] -> Bool
+prop_numEvensLength nums =
+    numEvens nums <= length nums
+
+
+prop_numManyEvensDoubled :: [[Int]] -> Bool
+prop_numManyEvensDoubled listsOfNums =
+    let doubled = listsOfNums ++ listsOfNums
+    in
+        numManyEvens doubled == 2 * (numManyEvens listsOfNums)
+
+-------------------------------------------------------------------------------
+
+main :: IO ()
+main = do
+    quickCheck prop_celsius0
+    quickCheck prop_celsius37
+    quickCheck prop_nCopiesLength
+    quickCheck prop_numEvensLength
+    quickCheck prop_numManyEvensDoubled

--- a/testers/testers/java/tests/script.py
+++ b/testers/testers/java/tests/script.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+from markus_java_tester import MarkusJavaTester
+from markus_tester import MarkusTestSpecs
+
+if __name__ == '__main__':
+
+    SPECS = MarkusTestSpecs()
+
+    """
+    The test files to run (uploaded as support files), and the points assigned:
+    points can be assigned per test function, or per test class (every test function in the class will be worth those
+    points); if a test function/class is missing, it is assigned a default of 1 point (use POINTS = {} for all 1s).
+    """
+    POINTS1 = {'testPasses': 1, 'testFails': 1}
+    POINTS2 = {'Test2': 2}
+    SPECS['test_points'] = {'Test1.java': POINTS1}
+    SPECS['test_points'] = {'Test2.java': POINTS2}
+
+    """
+    The feedback file name; defaults to no feedback file if commented out.
+    """
+    # SPECS['feedback_file'] = 'feedback_java.txt'
+
+    tester = MarkusJavaTester(specs=SPECS)
+    tester.run()

--- a/testers/testers/java/tests/script_files/Test1.java
+++ b/testers/testers/java/tests/script_files/Test1.java
@@ -1,0 +1,22 @@
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Test1 {
+
+    Submission submission = new Submission();
+
+    @Test
+    @DisplayName("This test should pass")
+    public void testPasses() {
+        assertTrue(submission.returnTrue());
+    }
+
+    @Test
+    @DisplayName("This test should fail")
+    public void testFails() {
+        assertTrue(submission.returnFalse());
+    }
+
+}

--- a/testers/testers/java/tests/script_files/Test2.java
+++ b/testers/testers/java/tests/script_files/Test2.java
@@ -1,0 +1,36 @@
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class Test2 {
+
+    Submission submission = new Submission();
+
+    @Test
+    @DisplayName("This test should timeout")
+    public void testLoops() {
+        assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+            Thread t = new Thread(() -> {
+                submission.loop();
+            });
+            t.start();
+            try {
+                t.join();
+            }
+            catch (InterruptedException e) {
+                t.stop();
+            }
+        });
+    }
+
+    @Test
+    @DisplayName("This test should fail and print json")
+    public void testFailsAndOutputsJson() {
+        fail(submission.returnJson());
+    }
+
+}

--- a/testers/testers/java/tests/specs.json
+++ b/testers/testers/java/tests/specs.json
@@ -1,0 +1,9 @@
+{
+  "path_to_tester_jars": "/path/to/tester/jars",
+  "feedback_file": null,
+  "enable_feedback_file_hook": false,
+  "hooks": null,
+  "script_files": [],
+  "support_files": [],
+  "points": {}
+}

--- a/testers/testers/java/tests/student_files/Submission.java
+++ b/testers/testers/java/tests/student_files/Submission.java
@@ -1,0 +1,21 @@
+public class Submission {
+
+    public Submission() {}
+
+    public boolean returnTrue() {
+        return true;
+    }
+
+    public boolean returnFalse() {
+        return false;
+    }
+
+    public void loop() {
+        while (true) {}
+    }
+
+    public String returnJson() {
+        return "]}[{\"\\";
+    }
+
+}

--- a/testers/testers/jdbc/tests/env_settings.json
+++ b/testers/testers/jdbc/tests/env_settings.json
@@ -1,0 +1,319 @@
+{
+  "matrix": [
+    {
+      "java_method_name": "CorrectNoOrder.CONNECTION",
+      "order_by": null,
+      "dataset_files": [
+        {
+          "dataset_file_path": null,
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "java_method_name": "CorrectNoOrder.DISCONNECTION",
+      "order_by": null,
+      "dataset_files": [
+        {
+          "dataset_file_path": null,
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "java_method_name": "CorrectNoOrder.select",
+      "order_by": null,
+      "dataset_files": [
+        {
+          "dataset_file_path": "data1j.sql",
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            }
+          ]
+        },
+        {
+          "dataset_file_path": "data2j.sql",
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "java_method_name": "CorrectNoOrder.insert",
+      "order_by": null,
+      "dataset_files": [
+        {
+          "dataset_file_path": "data1j.sql",
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            },
+            {
+              "table_name": "table1",
+              "points": 1
+            }
+          ]
+        },
+        {
+          "dataset_file_path": "data2j.sql",
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            },
+            {
+              "table_name": "table1",
+              "points": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "java_method_name": "CorrectWithOrder.select",
+      "order_by": true,
+      "dataset_files": [
+        {
+          "dataset_file_path": "data1j.sql",
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            }
+          ]
+        },
+        {
+          "dataset_file_path": "data2j.sql",
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "java_method_name": "BadConnection.CONNECTION",
+      "order_by": null,
+      "dataset_files": [
+        {
+          "dataset_file_path": null,
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "java_method_name": "ExceptionConnection.CONNECTION",
+      "order_by": null,
+      "dataset_files": [
+        {
+          "dataset_file_path": null,
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "java_method_name": "BadDisconnection.DISCONNECTION",
+      "order_by": null,
+      "dataset_files": [
+        {
+          "dataset_file_path": null,
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "java_method_name": "ExceptionDisconnection.DISCONNECTION",
+      "order_by": null,
+      "dataset_files": [
+        {
+          "dataset_file_path": null,
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "java_method_name": "BadSelect.select",
+      "order_by": null,
+      "dataset_files": [
+        {
+          "dataset_file_path": "data1j.sql",
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            }
+          ]
+        },
+        {
+          "dataset_file_path": "data2j.sql",
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "java_method_name": "ExceptionSelect.select",
+      "order_by": null,
+      "dataset_files": [
+        {
+          "dataset_file_path": "data1j.sql",
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            }
+          ]
+        },
+        {
+          "dataset_file_path": "data2j.sql",
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "java_method_name": "NoInsert.insert",
+      "order_by": null,
+      "dataset_files": [
+        {
+          "dataset_file_path": "data1j.sql",
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            },
+            {
+              "table_name": "table1",
+              "points": 1
+            }
+          ]
+        },
+        {
+          "dataset_file_path": "data2j.sql",
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            },
+            {
+              "table_name": "table1",
+              "points": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "java_method_name": "BadInsert.insert",
+      "order_by": null,
+      "dataset_files": [
+        {
+          "dataset_file_path": "data1j.sql",
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            },
+            {
+              "table_name": "table1",
+              "points": 1
+            }
+          ]
+        },
+        {
+          "dataset_file_path": "data2j.sql",
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            },
+            {
+              "table_name": "table1",
+              "points": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "java_method_name": "ExceptionInsert.insert",
+      "order_by": null,
+      "dataset_files": [
+        {
+          "dataset_file_path": "data1j.sql",
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            },
+            {
+              "table_name": "table1",
+              "points": 1
+            }
+          ]
+        },
+        {
+          "dataset_file_path": "data2j.sql",
+          "tables": [
+            {
+              "table_name": null,
+              "points": 1
+            },
+            {
+              "table_name": "table1",
+              "points": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "schema_file_path": "schema.ddl"
+}

--- a/testers/testers/jdbc/tests/environment_files/BadConnection.java
+++ b/testers/testers/jdbc/tests/environment_files/BadConnection.java
@@ -1,0 +1,8 @@
+public class BadConnection extends Solution {
+
+    public BadConnection() throws ClassNotFoundException {
+
+        super();
+    }
+
+}

--- a/testers/testers/jdbc/tests/environment_files/BadDisconnection.java
+++ b/testers/testers/jdbc/tests/environment_files/BadDisconnection.java
@@ -1,0 +1,8 @@
+public class BadDisconnection extends Solution {
+
+    public BadDisconnection() throws ClassNotFoundException {
+
+        super();
+    }
+
+}

--- a/testers/testers/jdbc/tests/environment_files/BadInsert.java
+++ b/testers/testers/jdbc/tests/environment_files/BadInsert.java
@@ -1,0 +1,8 @@
+public class BadInsert extends Solution {
+
+    public BadInsert() throws ClassNotFoundException {
+
+        super();
+    }
+
+}

--- a/testers/testers/jdbc/tests/environment_files/BadSelect.java
+++ b/testers/testers/jdbc/tests/environment_files/BadSelect.java
@@ -1,0 +1,8 @@
+public class BadSelect extends Solution {
+
+    public BadSelect() throws ClassNotFoundException {
+
+        super();
+    }
+
+}

--- a/testers/testers/jdbc/tests/environment_files/CorrectNoOrder.java
+++ b/testers/testers/jdbc/tests/environment_files/CorrectNoOrder.java
@@ -1,0 +1,27 @@
+import java.sql.PreparedStatement;
+
+public class CorrectNoOrder extends Solution {
+
+    public CorrectNoOrder() throws ClassNotFoundException {
+
+        super();
+    }
+
+    public boolean insert(String newWord) {
+
+        try {
+            String sql = "INSERT INTO table1(id, word) VALUES (?, ?)";
+            PreparedStatement statement = this.connection.prepareStatement(sql);
+            statement.setInt(1, 3);
+            statement.setString(2, newWord);
+            statement.executeUpdate();
+            statement.close();
+
+            return true;
+        }
+        catch (Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/testers/testers/jdbc/tests/environment_files/CorrectWithOrder.java
+++ b/testers/testers/jdbc/tests/environment_files/CorrectWithOrder.java
@@ -1,0 +1,35 @@
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CorrectWithOrder extends Solution {
+
+    public CorrectWithOrder() throws ClassNotFoundException {
+
+        super();
+    }
+
+    @Override
+    public List<String> select(Double numberThreshold) {
+
+        try {
+            String sql = "SELECT table1.word FROM table1 JOIN table2 ON table1.id = table2.foreign_id WHERE " +
+                    "table2.number > ? ORDER BY word";
+            PreparedStatement statement = this.connection.prepareStatement(sql);
+            statement.setDouble(1, numberThreshold);
+            ResultSet resultSet = statement.executeQuery();
+            List<String> result = new ArrayList<>();
+            while (resultSet.next()) {
+                result.add(resultSet.getString(1));
+            }
+            statement.close();
+
+            return result;
+        }
+        catch (Exception e) {
+            return null;
+        }
+    }
+
+}

--- a/testers/testers/jdbc/tests/environment_files/ExceptionConnection.java
+++ b/testers/testers/jdbc/tests/environment_files/ExceptionConnection.java
@@ -1,0 +1,8 @@
+public class ExceptionConnection extends Solution {
+
+    public ExceptionConnection() throws ClassNotFoundException {
+
+        super();
+    }
+
+}

--- a/testers/testers/jdbc/tests/environment_files/ExceptionDisconnection.java
+++ b/testers/testers/jdbc/tests/environment_files/ExceptionDisconnection.java
@@ -1,0 +1,8 @@
+public class ExceptionDisconnection extends Solution {
+
+    public ExceptionDisconnection() throws ClassNotFoundException {
+
+        super();
+    }
+
+}

--- a/testers/testers/jdbc/tests/environment_files/ExceptionInsert.java
+++ b/testers/testers/jdbc/tests/environment_files/ExceptionInsert.java
@@ -1,0 +1,8 @@
+public class ExceptionInsert extends Solution {
+
+    public ExceptionInsert() throws ClassNotFoundException {
+
+        super();
+    }
+
+}

--- a/testers/testers/jdbc/tests/environment_files/ExceptionSelect.java
+++ b/testers/testers/jdbc/tests/environment_files/ExceptionSelect.java
@@ -1,0 +1,8 @@
+public class ExceptionSelect extends Solution {
+
+    public ExceptionSelect() throws ClassNotFoundException {
+
+        super();
+    }
+
+}

--- a/testers/testers/jdbc/tests/environment_files/JDBCSubmission.java
+++ b/testers/testers/jdbc/tests/environment_files/JDBCSubmission.java
@@ -1,0 +1,28 @@
+import java.sql.Connection;
+
+public abstract class JDBCSubmission {
+
+    /**
+     * The connection used for this session.
+     */
+    public Connection connection;
+
+    /**
+     * Establishes a connection to the database, assigning it to the instance variable
+     * {@link JDBCSubmission#connection}.
+     *
+     * @param url The database url.
+     * @param username The username to connect to the database.
+     * @param password The password to connect to the database.
+     * @return True if connecting is successful, false otherwise.
+     */
+    public abstract boolean connectDB(String url, String username, String password);
+
+    /**
+     * Closes the database connection.
+     *
+     * @return True if closing was successful, false otherwise.
+     */
+    public abstract boolean disconnectDB();
+
+}

--- a/testers/testers/jdbc/tests/environment_files/NoInsert.java
+++ b/testers/testers/jdbc/tests/environment_files/NoInsert.java
@@ -1,0 +1,8 @@
+public class NoInsert extends Solution {
+
+    public NoInsert() throws ClassNotFoundException {
+
+        super();
+    }
+
+}

--- a/testers/testers/jdbc/tests/environment_files/Solution.java
+++ b/testers/testers/jdbc/tests/environment_files/Solution.java
@@ -1,0 +1,64 @@
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class Solution extends JDBCSubmission {
+
+    public Solution() throws ClassNotFoundException {
+
+        Class.forName("org.postgresql.Driver");
+    }
+
+    @Override
+    public boolean connectDB(String url, String username, String password) {
+
+        try {
+            this.connection = DriverManager.getConnection(url, username, password);
+            return true;
+        }
+        catch (SQLException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean disconnectDB() {
+
+        try {
+            this.connection.close();
+            return true;
+        }
+        catch (SQLException e) {
+            return false;
+        }
+    }
+
+    public List<String> select(Double numberThreshold) {
+
+        try {
+            String sql = "SELECT table1.word FROM table1 JOIN table2 ON table1.id = table2.foreign_id WHERE " +
+                         "table2.number > ?";
+            PreparedStatement statement = this.connection.prepareStatement(sql);
+            statement.setDouble(1, numberThreshold);
+            ResultSet resultSet = statement.executeQuery();
+            List<String> result = new ArrayList<>();
+            while (resultSet.next()) {
+                result.add(resultSet.getString(1));
+            }
+            statement.close();
+
+            return result;
+        }
+        catch (Exception e) {
+            return null;
+        }
+    }
+
+    public boolean insert(String newWord) {
+
+        // only CorrectNoOrder.insert() should insert the correct tuple
+        // in a real assignment with multiple files there should not be competing functions
+        return true;
+    }
+
+}

--- a/testers/testers/jdbc/tests/environment_files/data1j.sql
+++ b/testers/testers/jdbc/tests/environment_files/data1j.sql
@@ -1,0 +1,7 @@
+INSERT INTO table1 VALUES
+  (1, 'zzzz'),
+  (2, 'aaaa');
+
+INSERT INTO table2 VALUES
+  (1, 1.0, 1),
+  (2, 2.0, 2);

--- a/testers/testers/jdbc/tests/environment_files/data2j.sql
+++ b/testers/testers/jdbc/tests/environment_files/data2j.sql
@@ -1,0 +1,7 @@
+INSERT INTO table1 VALUES
+  (1, NULL),
+  (2, NULL);
+
+INSERT INTO table2 VALUES
+  (1, 1.0, 1),
+  (2, 2.0, 2);

--- a/testers/testers/jdbc/tests/environment_files/schema.ddl
+++ b/testers/testers/jdbc/tests/environment_files/schema.ddl
@@ -1,0 +1,10 @@
+CREATE TABLE table1 (
+  id serial PRIMARY KEY,
+  word varchar(50)
+);
+
+CREATE TABLE table2 (
+  id serial PRIMARY KEY,
+  number double precision NOT NULL,
+  foreign_id integer NOT NULL REFERENCES table1
+);

--- a/testers/testers/jdbc/tests/script.py
+++ b/testers/testers/jdbc/tests/script.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+from markus_jdbc_tester import MarkusJDBCTester
+from markus_tester import MarkusTestSpecs
+
+if __name__ == '__main__':
+
+    SPECS = MarkusTestSpecs()
+
+    # Students are required to extend JDBCSubmission.java
+
+    # The points assigned to each test case; points can be assigned in three ways:
+    # 1) to some tests+datasets
+    #    SPECS['points'] = {'test1': {'data1': 11, 'data2': 12}, 'test2': {'data1': 21, 'data2': 22}}
+    # 2) to all datasets of some tests
+    #    SPECS['test_points'] = {'test1': 1, 'test2': 2}
+    # 3) to all tests of some datasets
+    #    SPECS['data_points'] = {'data1': 1, 'data2': 2}
+    # If you don't specify some tests/datasets from the solution, they are assigned a default of 1 point.
+    SPECS['points'] = {'CorrectNoOrder.select':   {'data2j.sql': 2},
+                       'CorrectWithOrder.select': {'data2j.sql': 2},
+                       'BadSelect.select':        {'data2j.sql': 2},
+                       'ExceptionSelect.select':  {'data2j.sql': 2},
+                       'CorrectNoOrder.insert':   {'data2j.sql': {'JAVA': 2, 'table1': 2}},
+                       'NoInsert.insert':         {'data2j.sql': {'JAVA': 2, 'table1': 2}},
+                       'BadInsert.insert':        {'data2j.sql': {'JAVA': 2, 'table1': 2}},
+                       'ExceptionInsert.insert':  {'data2j.sql': {'JAVA': 2, 'table1': 2}}}
+
+    # The schema name (defaults to no schema if commented out).
+    SPECS['schema_name'] = 'autotest'
+
+    # The feedback file name (defaults to no feedback file if commented out).
+    # SPECS['feedback_file'] = 'feedback_jdbc.txt'
+
+    tester = MarkusJDBCTester(specs=SPECS)
+    tester.run()

--- a/testers/testers/jdbc/tests/specs.json
+++ b/testers/testers/jdbc/tests/specs.json
@@ -1,0 +1,52 @@
+{
+  "matrix": {
+    "CorrectNoOrder.CONNECTION": {
+      "nodata": 1
+    },
+    "CorrectNoOrder.DISCONNECTION": {
+      "nodata": 1
+    },
+    "CorrectNoOrder.select": {
+      "data1j.sql": 1, "data2j.sql": 1
+    },
+    "CorrectNoOrder.insert": {
+      "data1j.sql": {"JAVA": 1, "table1": 1}, "data2j.sql": {"JAVA": 1, "table1": 1}
+    },
+    "CorrectWithOrder.select": {
+      "data1j.sql": 1, "data2j.sql": 1,
+      "extra": {"order_on": true}
+    },
+    "BadConnection.CONNECTION": {
+      "nodata": 1
+    },
+    "ExceptionConnection.CONNECTION": {
+      "nodata": 1
+    },
+    "BadDisconnection.DISCONNECTION": {
+      "nodata": 1
+    },
+    "ExceptionDisconnection.DISCONNECTION": {
+      "nodata": 1
+    },
+    "BadSelect.select": {
+      "data1j.sql": 1, "data2j.sql": 1
+    },
+    "ExceptionSelect.select": {
+      "data1j.sql": 1, "data2j.sql": 1
+    },
+    "NoInsert.insert": {
+      "data1j.sql": {"JAVA": 1, "table1": 1}, "data2j.sql": {"JAVA": 1, "table1": 1}
+    },
+    "BadInsert.insert": {
+      "data1j.sql": {"JAVA": 1, "table1": 1}, "data2j.sql": {"JAVA": 1, "table1": 1}
+    },
+    "ExceptionInsert.insert": {
+      "data1j.sql": {"JAVA": 1, "table1": 1}, "data2j.sql": {"JAVA": 1, "table1": 1}
+    }
+  },
+  "path_to_jdbc_jar": "/path/to/jdbc/jar",
+  "oracle_database": "oracle_db",
+  "tests": [{"database": "test_db", "user": "test_user", "password": "test_password"}],
+  "path_to_solution": "/path/to/solution",
+  "feedback_file": null
+}

--- a/testers/testers/jdbc/tests/student_files/BadConnection.java
+++ b/testers/testers/jdbc/tests/student_files/BadConnection.java
@@ -1,0 +1,24 @@
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class BadConnection extends Submission {
+
+    public BadConnection() throws ClassNotFoundException {
+
+        super();
+    }
+
+    @Override
+    public boolean connectDB(String url, String username, String password) {
+
+        try {
+            this.connection = DriverManager.getConnection(url, username, password);
+            this.disconnectDB();
+            return true;
+        }
+        catch (SQLException e) {
+            return false;
+        }
+    }
+
+}

--- a/testers/testers/jdbc/tests/student_files/BadDisconnection.java
+++ b/testers/testers/jdbc/tests/student_files/BadDisconnection.java
@@ -1,0 +1,14 @@
+public class BadDisconnection extends Submission {
+
+    public BadDisconnection() throws ClassNotFoundException {
+
+        super();
+    }
+
+    @Override
+    public boolean disconnectDB() {
+
+        return true;
+    }
+
+}

--- a/testers/testers/jdbc/tests/student_files/BadInsert.java
+++ b/testers/testers/jdbc/tests/student_files/BadInsert.java
@@ -1,0 +1,27 @@
+import java.sql.PreparedStatement;
+
+public class BadInsert extends Submission {
+
+    public BadInsert() throws ClassNotFoundException {
+
+        super();
+    }
+
+    public boolean insert(String newWord) {
+
+        try {
+            String sql = "INSERT INTO table1(id, word) VALUES (?, ?)";
+            PreparedStatement statement = this.connection.prepareStatement(sql);
+            statement.setInt(1, 3);
+            statement.setString(2, newWord + "X");
+            statement.executeUpdate();
+            statement.close();
+
+            return true;
+        }
+        catch (Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/testers/testers/jdbc/tests/student_files/BadSelect.java
+++ b/testers/testers/jdbc/tests/student_files/BadSelect.java
@@ -1,0 +1,34 @@
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BadSelect extends Submission {
+
+    public BadSelect() throws ClassNotFoundException {
+
+        super();
+    }
+
+    public List<String> select(Double numberThreshold) {
+
+        try {
+            String sql = "SELECT CONCAT(table1.word, 'X') AS word FROM table1 JOIN table2 " +
+                         "ON table1.id = table2.foreign_id WHERE table2.number > ?";
+            PreparedStatement statement = this.connection.prepareStatement(sql);
+            statement.setDouble(1, numberThreshold);
+            ResultSet resultSet = statement.executeQuery();
+            List<String> result = new ArrayList<>();
+            while (resultSet.next()) {
+                result.add(resultSet.getString(1));
+            }
+            statement.close();
+
+            return result;
+        }
+        catch (Exception e) {
+            return null;
+        }
+    }
+
+}

--- a/testers/testers/jdbc/tests/student_files/CorrectNoOrder.java
+++ b/testers/testers/jdbc/tests/student_files/CorrectNoOrder.java
@@ -1,0 +1,51 @@
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CorrectNoOrder extends Submission {
+
+    public CorrectNoOrder() throws ClassNotFoundException {
+
+        super();
+    }
+
+    public List<String> select(Double numberThreshold) {
+
+        try {
+            String sql = "SELECT table1.word FROM table1 JOIN table2 ON table1.id = table2.foreign_id WHERE " +
+                         "table2.number > ?";
+            PreparedStatement statement = this.connection.prepareStatement(sql);
+            statement.setDouble(1, numberThreshold);
+            ResultSet resultSet = statement.executeQuery();
+            List<String> result = new ArrayList<>();
+            while (resultSet.next()) {
+                result.add(resultSet.getString(1));
+            }
+            statement.close();
+
+            return result;
+        }
+        catch (Exception e) {
+            return null;
+        }
+    }
+
+    public boolean insert(String newWord) {
+
+        try {
+            String sql = "INSERT INTO table1(id, word) VALUES (?, ?)";
+            PreparedStatement statement = this.connection.prepareStatement(sql);
+            statement.setInt(1, 3);
+            statement.setString(2, newWord);
+            statement.executeUpdate();
+            statement.close();
+
+            return true;
+        }
+        catch (Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/testers/testers/jdbc/tests/student_files/CorrectWithOrder.java
+++ b/testers/testers/jdbc/tests/student_files/CorrectWithOrder.java
@@ -1,0 +1,51 @@
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CorrectWithOrder extends Submission {
+
+    public CorrectWithOrder() throws ClassNotFoundException {
+
+        super();
+    }
+
+    public List<String> select(Double numberThreshold) {
+
+        try {
+            String sql = "SELECT table1.word FROM table1 JOIN table2 ON table1.id = table2.foreign_id WHERE " +
+                         "table2.number > ? ORDER BY word";
+            PreparedStatement statement = this.connection.prepareStatement(sql);
+            statement.setDouble(1, numberThreshold);
+            ResultSet resultSet = statement.executeQuery();
+            List<String> result = new ArrayList<>();
+            while (resultSet.next()) {
+                result.add(resultSet.getString(1));
+            }
+            statement.close();
+
+            return result;
+        }
+        catch (Exception e) {
+            return null;
+        }
+    }
+
+    public boolean insert(String newWord) {
+
+        try {
+            String sql = "INSERT INTO table1(id, word) VALUES (?, ?)";
+            PreparedStatement statement = this.connection.prepareStatement(sql);
+            statement.setInt(1, 3);
+            statement.setString(2, newWord);
+            statement.executeUpdate();
+            statement.close();
+
+            return true;
+        }
+        catch (Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/testers/testers/jdbc/tests/student_files/ExceptionConnection.java
+++ b/testers/testers/jdbc/tests/student_files/ExceptionConnection.java
@@ -1,0 +1,14 @@
+public class ExceptionConnection extends Submission {
+
+    public ExceptionConnection() throws ClassNotFoundException {
+
+        super();
+    }
+
+    @Override
+    public boolean connectDB(String url, String username, String password) {
+
+        throw new NullPointerException("Get this unchecked exception");
+    }
+
+}

--- a/testers/testers/jdbc/tests/student_files/ExceptionDisconnection.java
+++ b/testers/testers/jdbc/tests/student_files/ExceptionDisconnection.java
@@ -1,0 +1,14 @@
+public class ExceptionDisconnection extends Submission {
+
+    public ExceptionDisconnection() throws ClassNotFoundException {
+
+        super();
+    }
+
+    @Override
+    public boolean disconnectDB() {
+
+        throw new NullPointerException("Get this unchecked exception");
+    }
+
+}

--- a/testers/testers/jdbc/tests/student_files/ExceptionInsert.java
+++ b/testers/testers/jdbc/tests/student_files/ExceptionInsert.java
@@ -1,0 +1,13 @@
+public class ExceptionInsert extends Submission {
+
+    public ExceptionInsert() throws ClassNotFoundException {
+
+        super();
+    }
+
+    public boolean insert(String newWord) {
+
+        throw new NullPointerException("Get this unchecked exception");
+    }
+
+}

--- a/testers/testers/jdbc/tests/student_files/ExceptionSelect.java
+++ b/testers/testers/jdbc/tests/student_files/ExceptionSelect.java
@@ -1,0 +1,15 @@
+import java.util.List;
+
+public class ExceptionSelect extends Submission {
+
+    public ExceptionSelect() throws ClassNotFoundException {
+
+        super();
+    }
+
+    public List<String> select(Double numberThreshold) {
+
+        throw new NullPointerException("Get this unchecked exception");
+    }
+
+}

--- a/testers/testers/jdbc/tests/student_files/NoInsert.java
+++ b/testers/testers/jdbc/tests/student_files/NoInsert.java
@@ -1,0 +1,13 @@
+public class NoInsert extends Submission {
+
+    public NoInsert() throws ClassNotFoundException {
+
+        super();
+    }
+
+    public boolean insert(String newWord) {
+
+        return false;
+    }
+
+}

--- a/testers/testers/jdbc/tests/student_files/Submission.java
+++ b/testers/testers/jdbc/tests/student_files/Submission.java
@@ -1,0 +1,35 @@
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public abstract class Submission extends JDBCSubmission {
+
+    public Submission() throws ClassNotFoundException {
+
+        Class.forName("org.postgresql.Driver");
+    }
+
+    @Override
+    public boolean connectDB(String url, String username, String password) {
+
+        try {
+            this.connection = DriverManager.getConnection(url, username, password);
+            return true;
+        }
+        catch (SQLException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean disconnectDB() {
+
+        try {
+            this.connection.close();
+            return true;
+        }
+        catch (SQLException e) {
+            return false;
+        }
+    }
+
+}

--- a/testers/testers/py/tests/script.py
+++ b/testers/testers/py/tests/script.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+from markus_python_tester import MarkusPythonTester
+from markus_tester import MarkusTestSpecs
+
+if __name__ == '__main__':
+
+    SPECS = MarkusTestSpecs()
+
+    """
+    The test files to run (uploaded as support files), and the points assigned:
+    points can be assigned per test function, or per test class (every test function in the class will be worth those
+    points); if a test function/class is missing, it is assigned a default of 1 point (use POINTS = {} for all 1s).
+    """
+    POINTS = {}
+    SPECS['test_points'] = {'test.py': POINTS, 'test2.py': POINTS}
+
+    """
+    If using the pytest tester, set the traceback format, options are:
+        'auto', 'long', 'short', 'no', 'line', 'native'
+    The default is 'short' if commented out
+    """
+    # SPECS["pytest_tb_format"] = "short"
+
+    """
+    If using the unittest tester, set the verbosity level, options are: 0, 1, 2
+    The default is 2 if commented out
+    """
+    # SPECS["unittest_verbosity"] = 2
+
+    """
+    Choose which python tester to use, options are: 'pytest', 'unittest'
+    The default is 'pytest' if commented out
+    """
+    # SPECS["tester"] = "pytest"
+
+    """
+    The feedback file name; defaults to no feedback file if commented out.
+    """
+    # SPECS['feedback_file'] = 'feedback_python.txt'
+
+    tester = MarkusPythonTester(specs=SPECS)
+    tester.run()

--- a/testers/testers/py/tests/script_files/test.py
+++ b/testers/testers/py/tests/script_files/test.py
@@ -1,0 +1,31 @@
+import unittest
+try:
+    import submission
+except ImportError:
+    pass
+
+
+class Test1(unittest.TestCase):
+
+    def test_passes(self):
+        """This test should pass"""
+        self.assertTrue(submission.return_true())
+
+    def test_fails(self):
+        """This test should fail"""
+        self.assertTrue(submission.return_false())
+
+
+class Test2(unittest.TestCase):
+
+    def test_loops(self):
+        """This test should timeout"""
+        submission.loop()
+
+    def test_fails_and_outputs_json(self):
+        """This test should fail and print json"""
+        self.fail(submission.return_json())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/testers/testers/py/tests/script_files/test2.py
+++ b/testers/testers/py/tests/script_files/test2.py
@@ -1,0 +1,23 @@
+import pytest
+
+try:
+    import submission
+except ImportError:
+    pass
+
+def test_passes():
+	"""This test should pass"""
+	assert submission.return_true()
+
+def test_fails():
+	"""This test should fail"""
+	assert submission.return_false()
+
+@pytest.mark.timeout(10)
+def test_loops():
+	"""This test should timeout"""
+	submission.loop()
+
+def test_fails_and_outputs_json():
+	"""This test should fail and print json"""
+	pytest.fail(submission.return_json())

--- a/testers/testers/py/tests/specs.json
+++ b/testers/testers/py/tests/specs.json
@@ -1,0 +1,6 @@
+{
+  "feedback_file": null,
+  "pytest_tb_format": "short",
+  "unittest_verbosity": 2,
+  "tester": "pytest"
+}

--- a/testers/testers/py/tests/student_files/submission.py
+++ b/testers/testers/py/tests/student_files/submission.py
@@ -1,0 +1,14 @@
+def return_true():
+    return True
+
+
+def return_false():
+    return False
+
+
+def loop():
+    while True:
+        pass
+
+def return_json():
+    return ']}[{"\\'

--- a/testers/testers/pyta/tests/script_pyta.py
+++ b/testers/testers/pyta/tests/script_pyta.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+from markus_pyta_tester import MarkusPyTATester
+from markus_tester import MarkusTestSpecs
+
+if __name__ == '__main__':
+
+    SPECS = MarkusTestSpecs()
+
+    """
+    The student files to analyze with PyTA, and the points assigned; 1 point will be deducted per message occurrence, to
+    a minimum of 0.
+    """
+    SPECS['test_points'] = {'submission.py': 10}
+
+    """
+    The PyTA configuration; you can comment this out and use a support file named .pylintrc instead.
+    In either case, you should not specify 'pyta-output-file' and 'pyta-reporter'.
+    """
+    SPECS['pyta_config'] = {}
+
+    """
+    The feedback file name; defaults to no feedback file if commented out.
+    """
+    # SPECS['feedback_file'] = 'feedback_pyta.txt'
+
+    tester = MarkusPyTATester(specs=SPECS)
+    tester.run()

--- a/testers/testers/pyta/tests/specs.json
+++ b/testers/testers/pyta/tests/specs.json
@@ -1,0 +1,3 @@
+{
+  "feedback_file": null
+}

--- a/testers/testers/pyta/tests/student_files/submission.py
+++ b/testers/testers/pyta/tests/student_files/submission.py
@@ -1,0 +1,14 @@
+def return_true():
+    return True
+
+
+def return_false():
+    return False
+
+
+def loop():
+    while True:
+        pass
+
+def return_json():
+    return ']}[{"\\'

--- a/testers/testers/racket/tests/script.py
+++ b/testers/testers/racket/tests/script.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+from markus_racket_tester import MarkusRacketTester
+from markus_tester import MarkusTestSpecs
+
+if __name__ == '__main__':
+
+    SPECS = MarkusTestSpecs()
+
+    '''
+    The test files to run (uploaded as support files), and the points assigned:
+    points can be assigned per test.  If a test is missing, it is assigned a 
+    default of 1 point (use POINTS = {} for all 1s).
+    '''
+    POINTS = {}
+    SPECS['test_points'] = {'test.rkt': POINTS}
+
+    '''
+    The name of the test-suite defined in your test files (defaults to 'all-tests' seconds if commented out)
+    ex: 
+          (define all-tests (test-suite ...) )
+    This can either be a string indicating the test-suite name for all test files (defined in SPECS['test_points'])
+    or a dictionary mapping each test file name to different test-suite names (not recommended)
+    ex:
+          SPECS['test_suite_name'] = {'test.rkt': 'all-tests', 'test2.rkt': 'other-tests'}
+    '''
+    # SPECS['test_suite_name'] = 'all-tests'
+
+    '''
+    The feedback file name (defaults to no feedback file if commented out).
+    '''
+    # SPECS['feedback_file'] = 'feedback_racket.txt'
+
+    tester = MarkusRacketTester(specs=SPECS)
+    tester.run()

--- a/testers/testers/racket/tests/script_files/test.rkt
+++ b/testers/testers/racket/tests/script_files/test.rkt
@@ -1,0 +1,138 @@
+#!/usr/bin/env racket
+#lang racket
+
+(require "submission.rkt")
+(require (for-meta 1 "submission.rkt"))
+(require (for-meta 1 rackunit))
+(require (for-meta 1 racket/local))
+
+(require syntax/macro-testing)
+(require rackunit)
+
+(define all-tests
+  (test-suite
+   "All tests"
+
+   (test-suite
+    "Task 1"
+    (test-equal? "return" (return 1) (Just 1))
+    (test-equal? "bind success" (bind (Just 1) (lambda (n) (safe-div 10 n))) (Just 10))
+    (test-equal? "bind failure" (bind Nothing (lambda (n) (safe-div 10 n))) Nothing)
+
+    (test-suite
+     "Task 2"
+
+     (test-equal?
+      "do with a single expression"
+      (phase1-eval
+       (do-maybe
+        (Just 1)))
+      (Just 1))
+     
+     (test-equal?
+      "Simple do expression (sample test)"
+      (phase1-eval
+       (do-maybe
+        (x1 <- (parse-num "3"))
+        (x2 <- (parse-num "8"))
+        (return (+ x1 x2))))
+      (Just 12))
+     
+     
+     (test-equal?
+      "Simple do expression with Nothing (sample test)"
+      (phase1-eval
+       (do-maybe
+        (x1 <- (parse-num "3"))
+        (x2 <- (parse-num "david"))
+        (return (+ x1 x2))))
+      Nothing)
+
+     (test-equal?
+      "do with several succcessful expressions"
+      (phase1-eval
+       (do-maybe
+        (x1 <- (Just 4))
+        (x2 <- (Just 10))
+        (x3 <- (Just 100))
+        (x4 <- (Just 4))
+        (x5 <- (Just 6))
+        (Just (+ x1 x2 x3 x4 x5))))
+      (Just (+ 4 10 100 4 6)))
+
+     (test-equal?
+      "do with some failure expressions"
+      (phase1-eval
+       (do-maybe
+        (x1 <- (Just 4))
+        (x2 <- (Just 10))
+        (x3 <- (Just 100))
+        (x4 <- (Just 4))
+        (x5 <- Nothing)
+        (Just (+ x1 x2 x3 x4 x5))))
+      Nothing)
+     )
+
+    (test-suite
+     "Task 3"
+     (test-equal?
+      "Do notation without explicit bind (sample test)"
+      (phase1-eval (do-maybe
+                    (Just 1)
+                    (Just 2)
+                    (Just 3)
+                    (Just 4)))
+      (Just 4))
+
+     (test-equal?
+      "Do notation without explicit bind, with a Nothing (sample test)"
+      (phase1-eval (do-maybe
+                    (Just 1)
+                    (Just 2)
+                    Nothing
+                    (Just 4)))
+      Nothing)
+
+     (test-equal?
+      "Do notation mixing bind and standalone expressions"
+      (phase1-eval (do-maybe
+                    (x1 <- (Just 2))
+                    (Just x1)
+                    (x2 <- (Just 10))
+                    (Just (+ x1 x2))))
+      (Just 12))
+     
+     (test-equal?
+      "Using let to bind a pure value (sample test)"
+      (phase1-eval (do-maybe
+                    (do-let x 50)
+                    (do-let y 8)
+                    (safe-div x y)))
+      (Just 6))
+
+     (test-equal?
+      "Mixing let and bind (sample test)"
+      (phase1-eval (do-maybe
+                    (x <- (parse-num "3"))
+                    (do-let y (+ x 10))
+                    (return y)))
+      (Just 13))
+
+     (test-equal?
+      "Mixing let and bind with failure (sample test)"
+      (phase1-eval (do-maybe
+                    (x <- (parse-num "david"))
+                    (do-let y (+ x 10))
+                    (return y)))
+      Nothing)
+
+     (test-equal?
+      "Mixing let and standalone expressions (1)"
+      (phase1-eval (do-maybe
+                    (do-let x1 5)
+                    (safe-div 10 x1)
+                    (do-let y1 0)
+                    (safe-div 10 y1)
+                    (Just (+ x1 y1))))
+      Nothing)
+     ))))

--- a/testers/testers/racket/tests/specs.json
+++ b/testers/testers/racket/tests/specs.json
@@ -1,0 +1,4 @@
+{
+  "feedback_file": null,
+  "test_suite_name" : "all-tests"
+}

--- a/testers/testers/racket/tests/student_files/submission.rkt
+++ b/testers/testers/racket/tests/student_files/submission.rkt
@@ -1,0 +1,91 @@
+#lang racket #| CSC324 Winter 2018: Exercise 8 |#
+#|
+★ Before starting, please review the exercise guidelines at
+https://www.cs.toronto.edu/~david/csc324/homework.html ★
+|#
+(provide Nothing Just
+         safe-div parse-num
+         bind return do-maybe)
+
+
+;-------------------------------------------------------------------------------
+; Task 1: Modeling Maybe in Racket
+;-------------------------------------------------------------------------------
+(define Nothing 'Nothing)
+(define (Just x) (list 'Just x))
+
+
+#|
+(safe-div x y)
+  x: int
+  y: int
+
+  If y equals 0, returns Nothing.
+  Else returns (quotient x y)---wrapped in a Just, of course!
+|#
+(define (safe-div x y)
+  (if (zero? y) 'Nothing
+      (Just (quotient x y))
+      ))
+
+#|
+(parse-num s)
+  s: a string
+
+  If an int can be parsed from s by using `string->number`, then
+  succeed with that int. Else fail and return Nothing.
+|#
+(define (parse-num s)
+  (if (string->number s)
+      (Just (string->number s))
+      'Nothing
+      ))
+
+
+; Equivalents of `return` and `(>>=)` for Maybe.
+; (bind x f) should be equivalent to x >>= f in Haskell.
+; Make sure you get the type signature for (>>=) correct from Haskell!
+(define return Just)
+
+(define (fromJust e)
+  (if (list? e)
+      (second e)
+      (error "Tried to fromJust" e)))
+
+(define (bind x f)
+  (cond
+    [(equal? x 'Nothing)  'Nothing]
+    [(not (list? x))      (error "not a maybe" x)]
+    [(not (procedure? f)) (error "not a procedure" f)]
+    [else                 (f (fromJust x))]))
+
+;-------------------------------------------------------------------------------
+; Tasks 2 and 3: do notation in Racket
+;-------------------------------------------------------------------------------
+
+(define-syntax do-maybe
+  (syntax-rules (do-let <-)
+
+    [(do-maybe <bindings> ...  (do-let <id> <bind-expr>) <expr>)
+     (do-maybe
+       <bindings> ...
+       (<id> <- (Just <bind-expr>))
+       <expr>)]
+
+    [(do-maybe <bindings> ... (<id> <- <bind-expr>) <expr>)
+     (do-maybe
+       <bindings> ...
+       (bind <bind-expr> (lambda (<id>)
+       <expr>)))]
+
+    [(do-maybe <bindings> ... <bind-expr> <expr>)
+     (do-maybe
+       <bindings> ...
+       (_ <- <bind-expr>)
+       <expr>)]
+
+    [(do-maybe <expr>)
+       <expr>]
+  )
+)
+

--- a/testers/testers/sql/tests/env_settings.json
+++ b/testers/testers/sql/tests/env_settings.json
@@ -1,0 +1,188 @@
+{
+  "matrix":
+    [
+      {
+        "solution_file_path": "correct_no_order.sql",
+        "order_by": null,
+        "dataset_files": [
+          {
+            "dataset_file_path": "data1.sql",
+            "points": 1
+          },
+          {
+            "dataset_file_path": "data2.sql",
+            "points": 1
+          }
+        ]
+      },
+            {
+        "solution_file_path": "correct_with_order.sql",
+        "order_by": "word",
+        "dataset_files": [
+          {
+            "dataset_file_path": "data1.sql",
+            "points": 1
+          },
+          {
+            "dataset_file_path": "data2.sql",
+            "points": 1
+          }
+        ]
+      },
+            {
+        "solution_file_path": "bad_col_count.sql",
+        "order_by": null,
+        "dataset_files": [
+          {
+            "dataset_file_path": "data1.sql",
+            "points": 1
+          },
+          {
+            "dataset_file_path": "data2.sql",
+            "points": 1
+          }
+        ]
+      },
+            {
+        "solution_file_path": "bad_col_name.sql",
+        "order_by": null,
+        "dataset_files": [
+          {
+            "dataset_file_path": "data1.sql",
+            "points": 1
+          },
+          {
+            "dataset_file_path": "data2.sql",
+            "points": 1
+          }
+        ]
+      },
+            {
+        "solution_file_path": "bad_col_order.sql",
+        "order_by": null,
+        "dataset_files": [
+          {
+            "dataset_file_path": "data1.sql",
+            "points": 1
+          },
+          {
+            "dataset_file_path": "data2.sql",
+            "points": 1
+          }
+        ]
+      },
+            {
+        "solution_file_path": "bad_col_type.sql",
+        "order_by": null,
+        "dataset_files": [
+          {
+            "dataset_file_path": "data1.sql",
+            "points": 1
+          },
+          {
+            "dataset_file_path": "data2.sql",
+            "points": 1
+          }
+        ]
+      },
+            {
+        "solution_file_path": "bad_row_count.sql",
+        "order_by": null,
+        "dataset_files": [
+          {
+            "dataset_file_path": "data1.sql",
+            "points": 1
+          },
+          {
+            "dataset_file_path": "data2.sql",
+            "points": 1
+          }
+        ]
+      },
+                  {
+        "solution_file_path": "bad_row_order.sql",
+        "order_by": "word",
+        "dataset_files": [
+          {
+            "dataset_file_path": "data1.sql",
+            "points": 1
+          },
+          {
+            "dataset_file_path": "data2.sql",
+            "points": 1
+          }
+        ]
+      },
+                  {
+        "solution_file_path": "bad_row_content_no_order.sql",
+        "order_by": null,
+        "dataset_files": [
+          {
+            "dataset_file_path": "data1.sql",
+            "points": 1
+          },
+          {
+            "dataset_file_path": "data2.sql",
+            "points": 1
+          }
+        ]
+      },
+                  {
+        "solution_file_path": "bad_row_content_with_order.sql",
+        "order_by": "word",
+        "dataset_files": [
+          {
+            "dataset_file_path": "data1.sql",
+            "points": 1
+          },
+          {
+            "dataset_file_path": "data2.sql",
+            "points": 1
+          }
+        ]
+      },
+                  {
+        "solution_file_path": "bad_query.sql",
+        "order_by": null,
+        "dataset_files": [
+          {
+            "dataset_file_path": "data1.sql",
+            "points": 1
+          },
+          {
+            "dataset_file_path": "data2.sql",
+            "points": 1
+          }
+        ]
+      },
+                        {
+        "solution_file_path": "compatible_column_type.sql",
+        "order_by": null,
+        "dataset_files": [
+          {
+            "dataset_file_path": "data1.sql",
+            "points": 1
+          },
+          {
+            "dataset_file_path": "data2.sql",
+            "points": 1
+          }
+        ]
+      },
+                        {
+        "solution_file_path": "missing.sql",
+        "order_by": null,
+        "dataset_files": [
+          {
+            "dataset_file_path": "data1.sql",
+            "points": 1
+          },
+          {
+            "dataset_file_path": "data2.sql",
+            "points": 1
+          }
+        ]
+      }
+    ],
+  "schema_file_path": "schema.ddl"
+}

--- a/testers/testers/sql/tests/environment_files/bad_col_count.sql
+++ b/testers/testers/sql/tests/environment_files/bad_col_count.sql
@@ -1,0 +1,8 @@
+CREATE TABLE bad_col_count (
+  word varchar(50),
+  number double precision
+);
+
+INSERT INTO bad_col_count
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/environment_files/bad_col_name.sql
+++ b/testers/testers/sql/tests/environment_files/bad_col_name.sql
@@ -1,0 +1,8 @@
+CREATE TABLE bad_col_name (
+  word varchar(50),
+  number double precision
+);
+
+INSERT INTO bad_col_name
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/environment_files/bad_col_order.sql
+++ b/testers/testers/sql/tests/environment_files/bad_col_order.sql
@@ -1,0 +1,8 @@
+CREATE TABLE bad_col_order (
+  word varchar(50),
+  number double precision
+);
+
+INSERT INTO bad_col_order
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/environment_files/bad_col_type.sql
+++ b/testers/testers/sql/tests/environment_files/bad_col_type.sql
@@ -1,0 +1,8 @@
+CREATE TABLE bad_col_type (
+  word varchar(50),
+  number double precision
+);
+
+INSERT INTO bad_col_type
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/environment_files/bad_query.sql
+++ b/testers/testers/sql/tests/environment_files/bad_query.sql
@@ -1,0 +1,8 @@
+CREATE TABLE bad_query (
+  word varchar(50),
+  number double precision
+);
+
+INSERT INTO bad_query
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/environment_files/bad_row_content_no_order.sql
+++ b/testers/testers/sql/tests/environment_files/bad_row_content_no_order.sql
@@ -1,0 +1,8 @@
+CREATE TABLE bad_row_content_no_order (
+  word varchar(50),
+  number double precision
+);
+
+INSERT INTO bad_row_content_no_order
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/environment_files/bad_row_content_with_order.sql
+++ b/testers/testers/sql/tests/environment_files/bad_row_content_with_order.sql
@@ -1,0 +1,8 @@
+CREATE TABLE bad_row_content_with_order (
+  word varchar(50),
+  number double precision
+);
+
+INSERT INTO bad_row_content_with_order
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/environment_files/bad_row_count.sql
+++ b/testers/testers/sql/tests/environment_files/bad_row_count.sql
@@ -1,0 +1,8 @@
+CREATE TABLE bad_row_count (
+  word varchar(50),
+  number double precision
+);
+
+INSERT INTO bad_row_count
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/environment_files/bad_row_order.sql
+++ b/testers/testers/sql/tests/environment_files/bad_row_order.sql
@@ -1,0 +1,8 @@
+CREATE TABLE bad_row_order (
+  word varchar(50),
+  number double precision
+);
+
+INSERT INTO bad_row_order
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/environment_files/compatible_column_type.sql
+++ b/testers/testers/sql/tests/environment_files/compatible_column_type.sql
@@ -1,0 +1,8 @@
+CREATE TABLE compatible_column_type (
+  word varchar(50),
+  number double precision
+);
+
+INSERT INTO compatible_column_type
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/environment_files/correct_no_order.sql
+++ b/testers/testers/sql/tests/environment_files/correct_no_order.sql
@@ -1,0 +1,8 @@
+CREATE TABLE correct_no_order (
+  word varchar(50),
+  number double precision
+);
+
+INSERT INTO correct_no_order
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/environment_files/correct_with_order.sql
+++ b/testers/testers/sql/tests/environment_files/correct_with_order.sql
@@ -1,0 +1,8 @@
+CREATE TABLE correct_with_order (
+  word varchar(50),
+  number double precision
+);
+
+INSERT INTO correct_with_order
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/environment_files/data1.sql
+++ b/testers/testers/sql/tests/environment_files/data1.sql
@@ -1,0 +1,7 @@
+INSERT INTO table1 VALUES
+  (1, 'zzzz'),
+  (2, 'aaaa');
+
+INSERT INTO table2 VALUES
+  (1, 1.0, 1),
+  (2, 2.0, 2);

--- a/testers/testers/sql/tests/environment_files/data2.sql
+++ b/testers/testers/sql/tests/environment_files/data2.sql
@@ -1,0 +1,7 @@
+INSERT INTO table1 VALUES
+  (1, NULL),
+  (2, NULL);
+
+INSERT INTO table2 VALUES
+  (1, 1.0, 1),
+  (2, 2.0, 2);

--- a/testers/testers/sql/tests/environment_files/missing.sql
+++ b/testers/testers/sql/tests/environment_files/missing.sql
@@ -1,0 +1,8 @@
+CREATE TABLE missing (
+  word varchar(50),
+  number double precision
+);
+
+INSERT INTO missing
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/environment_files/schema.ddl
+++ b/testers/testers/sql/tests/environment_files/schema.ddl
@@ -1,0 +1,10 @@
+CREATE TABLE table1 (
+  id serial PRIMARY KEY,
+  word varchar(50)
+);
+
+CREATE TABLE table2 (
+  id serial PRIMARY KEY,
+  number double precision NOT NULL,
+  foreign_id integer NOT NULL REFERENCES table1
+);

--- a/testers/testers/sql/tests/script.py
+++ b/testers/testers/sql/tests/script.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+from markus_sql_tester import MarkusSQLTester
+from markus_tester import MarkusTestSpecs
+
+if __name__ == '__main__':
+
+    SPECS = MarkusTestSpecs()
+
+    # Students are required to create a solution table in their submission, named as the sql file without the file
+    # extension; e.g. an 'example.sql' file must have a 'CREATE TABLE example [...];' in it.
+    # Students are also required to submit an additional sql file with '_order' suffix for each submission that cares
+    # about ordering, which selects from their solution table and does the ordering; e.g. an 'example.sql' file must
+    # have an additional 'example_order.sql' file with a 'SELECT * FROM example ORDER BY [...];' in it)
+
+    # The points assigned to each test case; points can be assigned in three ways:
+    # 1) to some tests+datasets
+    #    SPECS['points'] = {'test1': {'data1': 11, 'data2': 12}, 'test2': {'data1': 21, 'data2': 22}}
+    # 2) to all datasets of some tests
+    #    SPECS['test_points'] = {'test1': 1, 'test2': 2}
+    # 3) to all tests of some datasets
+    #    SPECS['data_points'] = {'data1': 1, 'data2': 2}
+    # If you don't specify some tests/datasets from the solution, they are assigned a default of 1 point.
+    SPECS['data_points'] = {'data1.sql': 1, 'data2.sql': 2}
+
+    # The schema name (defaults to no schema if commented out).
+    SPECS['schema_name'] = 'autotest'
+
+    # The feedback file name (defaults to no feedback file if commented out).
+    # SPECS['feedback_file'] = 'feedback_sql.txt'
+
+    tester = MarkusSQLTester(specs=SPECS)
+    tester.run()

--- a/testers/testers/sql/tests/student_files/bad_col_count.sql
+++ b/testers/testers/sql/tests/student_files/bad_col_count.sql
@@ -1,0 +1,5 @@
+SET search_path TO ate;
+
+CREATE TABLE bad_col_count AS
+  SELECT table1.word
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/student_files/bad_col_name.sql
+++ b/testers/testers/sql/tests/student_files/bad_col_name.sql
@@ -1,0 +1,5 @@
+SET search_path TO ate;
+
+CREATE TABLE bad_col_name AS
+  SELECT table1.word AS badword, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/student_files/bad_col_order.sql
+++ b/testers/testers/sql/tests/student_files/bad_col_order.sql
@@ -1,0 +1,5 @@
+SET search_path TO ate;
+
+CREATE TABLE bad_col_order AS
+  SELECT table2.number, table1.word
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/student_files/bad_col_type.sql
+++ b/testers/testers/sql/tests/student_files/bad_col_type.sql
@@ -1,0 +1,5 @@
+SET search_path TO ate;
+
+CREATE TABLE bad_col_type AS
+  SELECT table1.word, table2.id AS number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/student_files/bad_query.sql
+++ b/testers/testers/sql/tests/student_files/bad_query.sql
@@ -1,0 +1,3 @@
+SET search_path TO ate;
+
+CREATE TABLE bad_query AS;

--- a/testers/testers/sql/tests/student_files/bad_row_content_no_order.sql
+++ b/testers/testers/sql/tests/student_files/bad_row_content_no_order.sql
@@ -1,0 +1,5 @@
+SET search_path TO ate;
+
+CREATE TABLE bad_row_content_no_order AS
+  SELECT CAST(CONCAT(table1.word, 'X') AS varchar(50)) AS word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/student_files/bad_row_content_with_order.sql
+++ b/testers/testers/sql/tests/student_files/bad_row_content_with_order.sql
@@ -1,0 +1,5 @@
+SET search_path TO ate;
+
+CREATE TABLE bad_row_content_with_order AS
+  SELECT CAST(CONCAT(table1.word, 'X') AS varchar(50)) AS word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/student_files/bad_row_content_with_order_order.sql
+++ b/testers/testers/sql/tests/student_files/bad_row_content_with_order_order.sql
@@ -1,0 +1,4 @@
+SET search_path TO ate;
+
+SELECT * FROM bad_row_content_with_order
+ORDER BY word;

--- a/testers/testers/sql/tests/student_files/bad_row_count.sql
+++ b/testers/testers/sql/tests/student_files/bad_row_count.sql
@@ -1,0 +1,7 @@
+SET search_path TO ate;
+
+CREATE TABLE bad_row_count AS
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id
+  UNION ALL
+  SELECT CAST('zzzz' AS varchar(50)) AS word, CAST(9.99 AS double precision) AS number;

--- a/testers/testers/sql/tests/student_files/bad_row_order.sql
+++ b/testers/testers/sql/tests/student_files/bad_row_order.sql
@@ -1,0 +1,5 @@
+SET search_path TO ate;
+
+CREATE TABLE bad_row_order AS
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/student_files/bad_row_order_order.sql
+++ b/testers/testers/sql/tests/student_files/bad_row_order_order.sql
@@ -1,0 +1,4 @@
+SET search_path TO ate;
+
+SELECT * FROM bad_row_order
+ORDER BY word DESC;

--- a/testers/testers/sql/tests/student_files/compatible_column_type.sql
+++ b/testers/testers/sql/tests/student_files/compatible_column_type.sql
@@ -1,0 +1,5 @@
+SET search_path TO ate;
+
+CREATE TABLE compatible_column_type AS
+  SELECT CAST(table1.word AS text) AS word, CAST(table2.number AS real) AS number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/student_files/correct_no_order.sql
+++ b/testers/testers/sql/tests/student_files/correct_no_order.sql
@@ -1,0 +1,5 @@
+SET search_path TO ate;
+
+CREATE TABLE correct_no_order AS
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/student_files/correct_with_order.sql
+++ b/testers/testers/sql/tests/student_files/correct_with_order.sql
@@ -1,0 +1,5 @@
+SET search_path TO ate;
+
+CREATE TABLE correct_with_order AS
+  SELECT table1.word, table2.number
+  FROM table1 JOIN table2 ON table1.id = table2.foreign_id;

--- a/testers/testers/sql/tests/student_files/correct_with_order_order.sql
+++ b/testers/testers/sql/tests/student_files/correct_with_order_order.sql
@@ -1,0 +1,4 @@
+SET search_path TO ate;
+
+SELECT * FROM correct_with_order
+ORDER BY word;


### PR DESCRIPTION
* adds back fixture files that used to be in the testers/*/client directories
* these will be used when designing future tester unittests

(All PRs labeled with the name "Autotest future" should be pulled in in order)