### PR TITLE
Autotest future (Part 7): unify specs for sql and jdbc testers

### DIFF
--- a/testers/testers/jdbc/bin/create_environment.sh
+++ b/testers/testers/jdbc/bin/create_environment.sh
@@ -17,11 +17,13 @@ get_method_names() {
 python3 - <<EOPY
 import json
 settings = json.loads('${JSONSETTINGS}')
-matrix = settings['matrix']
-for x in matrix:
-	name = x['java_method_name']
-	if 'CONNECTION' not in name:
+solution_group = settings['solution_group']
+names = set()
+for group in solution_group:
+	name = group['java_method_name']
+	if 'CONNECTION' not in name and name not in names:
 		print(name)
+	names.add(name)
 EOPY
 }
 
@@ -29,11 +31,10 @@ get_datasets_from_method_name() {
 python3 - <<EOPY
 import json
 settings = json.loads('${JSONSETTINGS}')
-datasets = settings['matrix']
-for dataset in datasets:
-	if dataset['java_method_name'] == '$1':
-		for x in dataset['dataset_files']:
-			print(x['dataset_file_path'])
+solution_group = settings['solution_group']
+for group in solution_group:
+	if group['java_method_name'] == '$1'
+		print(group['dataset_file_path'])
 EOPY
 }
 
@@ -95,8 +96,21 @@ load_solutions_to_db() {
 	done
 }
 
+get_class_files_to_keep() {
+python3 - <<EOPY
+import json, os
+settings = json.loads('${JSONSETTINGS}')
+java_class_files = settings['java_class_files']
+to_keep = {'MarkusJDBCTest.class'}
+for group in java_class_files:
+	if group['available_for_tests']:
+		to_keep.add(f'{os.path.splitext(group['dataset_file_path'])[0]}.class')
+print('|'.join(to_keep))
+EOPY
+}
+
 clean_solutions_dir() {
-	rm -f ${SOLUTIONDIR}/!(@(MarkusJDBCTest*.class|JDBCSubmission*.class|*.sql|*.ddl))
+	rm -f ${SOLUTIONDIR}/!(@($(get_class_files_to_keep)|*.sql|*.ddl))
 }
 
 get_setting() {

--- a/testers/testers/jdbc/bin/destroy_environment.sh
+++ b/testers/testers/jdbc/bin/destroy_environment.sh
@@ -4,25 +4,28 @@ set -e
 
 get_method_names() {
 python3 - <<EOPY
-import sys, json
+import json
 with open('${ENVSETTINGS}') as f:
 	settings = json.load(f)
-matrix = settings['matrix']
-for x in matrix:
-	name = x['java_method_name']
-	if 'CONNECTION' not in name:
+solution_group = settings['solution_group']
+names = set()
+for group in solution_group:
+	name = group['java_method_name']
+	if 'CONNECTION' not in name and name not in names:
 		print(name)
+	names.add(name)
 EOPY
 }
 
 get_datasets_from_method_name() {
 python3 - <<EOPY
-import sys, json
+import json
 with open('${ENVSETTINGS}') as f:
 	settings = json.load(f)
-datasets = settings['matrix']['$1']['dataset_files']
-for x in datasets:
-	print(x['dataset_file_path'])
+solution_group = settings['solution_group']
+for group in solution_group:
+	if group['java_method_name'] == '$1'
+		print(group['dataset_file_path'])
 EOPY
 }
 

--- a/testers/testers/jdbc/specs/default_environment_settings.json
+++ b/testers/testers/jdbc/specs/default_environment_settings.json
@@ -1,21 +1,15 @@
 {
-	"matrix":
-		[
-			{
-				"java_method_name": null,
-				"order_by": null,
-				"dataset_files": [
-					{
-						"dataset_file_path": null,
-						"tables": [
-							{
-								"table_name": null,
-								"points": 1
-							}
-						]
-					}
-				]
-			}
-		],
+	"solution_group" : [
+		{
+			"java_method_name" : null,
+			"dataset_file_path" : null
+		}
+	],
+	"java_class_files" : [
+		{
+			"java_file_path" : null,
+			"available_for_tests" : false
+		}
+	],
 	"schema_file_path": null
 }

--- a/testers/testers/jdbc/specs/default_settings.json
+++ b/testers/testers/jdbc/specs/default_settings.json
@@ -1,11 +1,13 @@
 {
-  	"runnable_group": [
+	"runnable_group": [
 		{
-			"solution_file_path": null,
-			"dataset_file_path": null
+			"java_method_name": null,
+			"dataset_file_path": null,
+			"table_name": null,
+			"order_on": null,
+			"points": 1
 		}
 	],
 	"enable_feedback_file_hook": false,
-	"feedback_file": null,
-	"points": {}
+	"feedback_file": null
 }

--- a/testers/testers/jdbc/specs/default_settings.json
+++ b/testers/testers/jdbc/specs/default_settings.json
@@ -3,7 +3,12 @@
 		{
 			"java_method_name": null,
 			"dataset_file_path": null,
-			"table_name": null,
+			"tables": [
+				{
+					"table_name": null,
+					"points": 1 
+				}
+			],
 			"order_on": null,
 			"points": 1
 		}

--- a/testers/testers/jdbc/specs/environment_ignore.yml
+++ b/testers/testers/jdbc/specs/environment_ignore.yml
@@ -1,2 +1,0 @@
-- order_by
-- points

--- a/testers/testers/jdbc/specs/environment_settings.yml
+++ b/testers/testers/jdbc/specs/environment_settings.yml
@@ -7,21 +7,18 @@ UPLOADFILES:
     REPEAT: '+'
 
 METADATA:
-  matrix:
+  solution_group:
     REPEAT+:
       java_method_name:
+        TEXT_MATCHER+: .+
+      dataset_file_path:
+        TEXT_MATCHER+: .+
+  java_class_files: 
+    REPEAT+:
+      java_file_path:
         TEXT_MATCHER: .+
-      dataset_files:
-        REPEAT+:
-          dataset_file_path:
-            TEXT_MATCHER: .+
-          tables:
-            REPEAT+:
-              table_names:
-                TEXT_MATCHER: .*
-              points:
-                TEXT_MATCHER: '\d+'
-                DEFAULT: "1"
-      order_by:
-        TEXT_MATCHER: .*
+      available_for_tests:
+        OPTIONS:
+          - true
+          - false
   schema_file_path: .+

--- a/testers/testers/jdbc/specs/settings.yml
+++ b/testers/testers/jdbc/specs/settings.yml
@@ -14,8 +14,13 @@ METADATA:
             TEXT_MATCHER: .+
           dataset_file_path:
             TEXT_MATCHER: .+
-          table_name:
-            TEXT_MATCHER: .*
+          tables:
+            REPEAT*:
+              table_name:
+                TEXT_MATCHER: .+
+              points:
+                TEXT_MATCHER: \d+
+                DEFAULT: '1'
           order_on:
             TEXT_MATCHER: .*
           points:

--- a/testers/testers/jdbc/specs/settings.yml
+++ b/testers/testers/jdbc/specs/settings.yml
@@ -10,10 +10,17 @@ METADATA:
     REPEAT+:
       runnable_group:
         REPEAT+:
-          solution_file_path: 
+          java_method_name: 
             TEXT_MATCHER: .+
           dataset_file_path:
             TEXT_MATCHER: .+
+          table_name:
+            TEXT_MATCHER: .*
+          order_on:
+            TEXT_MATCHER: .*
+          points:
+            TEXT_MATCHER: \d+
+            DEFAULT: '1'
       enable_feedback_file_hook:
         OPTIONS:
           - true

--- a/testers/testers/sql/bin/create_environment.sh
+++ b/testers/testers/sql/bin/create_environment.sh
@@ -11,9 +11,13 @@ get_query_files() {
 python3 - <<EOPY
 import json
 settings = json.loads('${JSONSETTINGS}')
-matrix = settings['matrix']
-for x in matrix:
-	print(x['solution_file_path'])
+solution_group = settings['solution_group']
+files = set()
+for group in solution_group:
+	solution_file = group['solution_file_path']
+	if solution_file not in files:
+		print(solution_file)
+	files.add(solution_file)
 EOPY
 }
 
@@ -21,11 +25,10 @@ get_datasets_from_query_file() {
 python3 - <<EOPY
 import json
 settings = json.loads('${JSONSETTINGS}')
-datasets = settings['matrix']
-for dataset in datasets:
-	if dataset['solution_file_path'] == '$1':
-		for x in dataset['dataset_files']:
-			print(x['dataset_file_path'])
+solution_group = settings['solution_group']
+for group in solution_group:
+	if group['solution_file_path'] == '$1':
+		print(group['dataset_file_path'])
 EOPY
 }
 

--- a/testers/testers/sql/bin/destroy_environment.sh
+++ b/testers/testers/sql/bin/destroy_environment.sh
@@ -7,9 +7,13 @@ python3 - <<EOPY
 import json
 with open('${ENVSETTINGS}') as f:
 	settings = json.load(f)
-matrix = settings['matrix']
-for x in matrix:
-	print(x['solution_file_path'])
+solution_group = settings['solution_group']
+files = set()
+for group in solution_group:
+	solution_file = group['solution_file_path']
+	if solution_file not in files:
+		print(solution_file)
+	files.add(solution_file)
 EOPY
 }
 
@@ -18,11 +22,10 @@ python3 - <<EOPY
 import json
 with open('${ENVSETTINGS}') as f:
 	settings = json.load(f)
-datasets = settings['matrix']
-for dataset in datasets:
-	if dataset['solution_file_path'] == '$1':
-		for x in dataset['dataset_files']:
-			print(x['dataset_file_path'])
+solution_group = settings['solution_group']
+for group in solution_group:
+	if group['solution_file_path'] == '$1':
+		print(group['dataset_file_path'])
 EOPY
 }
 

--- a/testers/testers/sql/specs/default_environment_settings.json
+++ b/testers/testers/sql/specs/default_environment_settings.json
@@ -1,16 +1,9 @@
 {
-	"matrix":
-		[
-			{
-				"solution_file_path": null,
-				"order_by": null,
-				"dataset_files": [
-					{
-						"dataset_file_path": null,
-						"points": 1
-					}
-				]
-			}
-		],
+	"solution_group" : [
+		{
+			"solution_file_path" : null,
+			"dataset_file_path" : null
+		}
+	],
 	"schema_file_path": null
 }

--- a/testers/testers/sql/specs/default_settings.json
+++ b/testers/testers/sql/specs/default_settings.json
@@ -1,11 +1,14 @@
 {
-  	"runnable_group": [
+	"runnable_group": [
 		{
 			"solution_file_path": null,
-			"dataset_file_path": null
+			"dataset_file_path": null,
+			"order_on": null,
+			"points": 1
 		}
 	],
+	"schema_name": "autotest",
 	"enable_feedback_file_hook": false,
 	"feedback_file": null,
-	"points": {}
+	"script_timeout": 30
 }

--- a/testers/testers/sql/specs/environment_ignore.yml
+++ b/testers/testers/sql/specs/environment_ignore.yml
@@ -1,2 +1,0 @@
-- order_by
-- points

--- a/testers/testers/sql/specs/environment_settings.yml
+++ b/testers/testers/sql/specs/environment_settings.yml
@@ -7,17 +7,10 @@ UPLOADFILES:
     REPEAT: '+'
 
 METADATA:
-  matrix:
+  solution_group:
     REPEAT+:
       solution_file_path:
-        TEXT_MATCHER: .+
-      dataset_files:
-        REPEAT+:
-          dataset_file_path:
-            TEXT_MATCHER: .+
-          points:
-            TEXT_MATCHER: '\d+'
-            DEFAULT: "1"
-      order_by:
-        TEXT_MATCHER: .*
+        TEXT_MATCHER+: .+
+      dataset_file_path:
+        TEXT_MATCHER+: .+
   schema_file_path: .+

--- a/testers/testers/sql/specs/settings.yml
+++ b/testers/testers/sql/specs/settings.yml
@@ -14,6 +14,11 @@ METADATA:
             TEXT_MATCHER: .+
           dataset_file_path:
             TEXT_MATCHER: .*
+          order_on:
+            TEXT_MATCHER: .*
+          points:
+            TEXT_MATCHER: \d+
+            DEFAULT: '1'
       enable_feedback_file_hook:
         OPTIONS:
           - true
@@ -25,3 +30,4 @@ METADATA:
         DEFAULT: "30"
       hooks_file_path:
         TEXT_MATCHER: .*
+        


### PR DESCRIPTION
This updates the specs for both the sql and jdbc testers so that they are more in line with the specs for other testers. Specifically, this introduces the idea of a true "runnable group" for these testers which is distinct from the solutions that were created at environment creation time. This will allow users to select a subset of the tests to run (if desired). 

(All PRs labeled with the name "Autotest future" should be pulled in in order)