### PR TITLE
Handle edge case that shouldn't happen when importing hooks module

### DIFF
--- a/server/autotest_server.py
+++ b/server/autotest_server.py
@@ -498,7 +498,8 @@ def load_hooks(hooks_script_path):
                 hooks_module = __import__(module_name)
         except Exception as e:
             return None, f'import error: {str(e)}\n'
-    return hooks_module, ''
+        return hooks_module, ''
+    return None, ''
 
 def run_hooks(hooks_module, function_name, tests_path, kwargs={}):
     """


### PR DESCRIPTION
The existence of the hooks file is checked before this function is called but it is still bad practice to create the potential for a local variable to not be set properly. 