### PR TITLE
autotest-future: changes to the markus tester base classes and the markus tester specs class

### DIFF
--- a/testers/testers/markus_test_specs.py
+++ b/testers/testers/markus_test_specs.py
@@ -1,9 +1,7 @@
 import json
 from collections.abc import Mapping
 
-
 class MarkusTestSpecs(Mapping):
-
     def __init__(self, *args, **kwargs):
         self._specs = dict(*args, **kwargs)
 
@@ -12,6 +10,19 @@ class MarkusTestSpecs(Mapping):
         return cls(json.loads(json_str))
 
     def __getitem__(self, key):
+        """
+        Behaves like a regular dict.__getitem__ except
+        if the key is not found and the key is a tuple
+        it will descend into any potential nested dictionaries
+        using each element in the tuple as a key in the next
+        nested dictionary
+
+        >>> my_dict = {'a':{'b':{'c':123}}}
+        >>> my_dict['a','b','c']
+        123
+        >>> my_dict['a','b']
+        {'c':123}
+        """
         try:
             return self._specs[key]
         except KeyError:
@@ -29,6 +40,20 @@ class MarkusTestSpecs(Mapping):
         return len(self._specs)
 
     def get(self, *keys, default=None):
+        """
+        Behaves like a regular dict.get except if there
+        are multiple keys it will use __getitem__ to
+        descend into any potential nested dictionaries.
+
+        >>> my_dict = {'a':{'b':{'c':123}}}
+        >>> my_dict.get('a','b','c')
+        123
+        >>> my_dict.get('a','b','d')
+        >>> my_dict.get('a','b','d', default=1)
+        1
+        >>> my_dict.get('b', 2, '5.', default=2)
+        2
+        """
         try:
             return super().get(keys, default=default)
         except TypeError:

--- a/testers/testers/markus_test_specs.py
+++ b/testers/testers/markus_test_specs.py
@@ -1,7 +1,9 @@
 import json
 from collections.abc import Mapping
 
+
 class MarkusTestSpecs(Mapping):
+
     def __init__(self, *args, **kwargs):
         self._specs = dict(*args, **kwargs)
 

--- a/testers/testers/markus_test_specs.py
+++ b/testers/testers/markus_test_specs.py
@@ -10,10 +10,24 @@ class MarkusTestSpecs(Mapping):
         return cls(json.loads(json_str))
 
     def __getitem__(self, key):
-        return self._specs[key]
+        try:
+            return self._specs[key]
+        except KeyError:
+            if isinstance(key, tuple):
+                d = self
+                for k in key:
+                    d = d[k]
+                return d
+            raise
 
     def __iter__(self):
         return iter(self._specs)
 
     def __len__(self):
         return len(self._specs)
+
+    def get(self, *keys, default=None):
+        try:
+            return super().get(keys, default=default)
+        except TypeError:
+            return default

--- a/testers/testers/markus_tester.py
+++ b/testers/testers/markus_tester.py
@@ -1,9 +1,9 @@
 from contextlib import contextmanager
 import enum
 import json
+import os
 from abc import ABC, abstractmethod
 from functools import wraps
-
 
 class MarkusTest(ABC):
 
@@ -192,6 +192,7 @@ class MarkusTest(ABC):
         """
         Callback invoked before running a test.
         Use this for test initialization steps that can fail, rather than using test_class.__init__().
+        :param test: The test after initialization.
         """
         pass
 
@@ -199,6 +200,7 @@ class MarkusTest(ABC):
         """
         Callback invoked after successfully running a test.
         Use this to access test data in the tester. Don't use this for test cleanup steps, use test_class.run() instead.
+        :param test: The test after execution.
         """
         pass
 
@@ -276,8 +278,8 @@ class MarkusTester(ABC):
     @contextmanager
     def open_feedback(filename, mode='w'):
         if filename:
+            feedback_open = open(filename, mode)
             try:
-                feedback_open = open(filename, mode)
                 yield feedback_open
             finally:
                 feedback_open.close()

--- a/testers/testers/markus_tester.py
+++ b/testers/testers/markus_tester.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 import enum
 import json
-import os
 from abc import ABC, abstractmethod
 from functools import wraps
 
@@ -192,7 +191,6 @@ class MarkusTest(ABC):
         """
         Callback invoked before running a test.
         Use this for test initialization steps that can fail, rather than using test_class.__init__().
-        :param test: The test after initialization.
         """
         pass
 
@@ -200,7 +198,6 @@ class MarkusTest(ABC):
         """
         Callback invoked after successfully running a test.
         Use this to access test data in the tester. Don't use this for test cleanup steps, use test_class.run() instead.
-        :param test: The test after execution.
         """
         pass
 

--- a/testers/testers/markus_tester.py
+++ b/testers/testers/markus_tester.py
@@ -4,6 +4,7 @@ import json
 from abc import ABC, abstractmethod
 from functools import wraps
 
+
 class MarkusTest(ABC):
 
     class Status(enum.Enum):

--- a/testers/testers/markus_tester.py
+++ b/testers/testers/markus_tester.py
@@ -1,9 +1,9 @@
 from contextlib import contextmanager
 import enum
 import json
-import os
 from abc import ABC, abstractmethod
 from functools import wraps
+
 
 class MarkusTest(ABC):
 
@@ -192,7 +192,6 @@ class MarkusTest(ABC):
         """
         Callback invoked before running a test.
         Use this for test initialization steps that can fail, rather than using test_class.__init__().
-        :param test: The test after initialization.
         """
         pass
 
@@ -200,7 +199,6 @@ class MarkusTest(ABC):
         """
         Callback invoked after successfully running a test.
         Use this to access test data in the tester. Don't use this for test cleanup steps, use test_class.run() instead.
-        :param test: The test after execution.
         """
         pass
 


### PR DESCRIPTION
Changes to MarkusTester/MarkusTest/MarkusTestSpecs required to pass settings in json-schema format and automatically update/create tester environments.

This PR should be tested in conjunction with https://github.com/MarkUsProject/Markus/pull/3875 on the MarkUs side and with #167.