### PR TITLE
Better error messages

### DIFF
--- a/server/autotest_server.py
+++ b/server/autotest_server.py
@@ -411,14 +411,13 @@ def test_run_command(test_username=None):
 
     return cmd
 
-def create_test_group_result(test_group_id, stdout, stderr, run_time, hooks_stderr, extra_data, timeout=None):
+def create_test_group_result(stdout, stderr, run_time, hooks_stderr, extra_data, timeout=None):
     """
     Return the arguments passed to this function in a dictionary. If stderr is 
     falsy, change it to None. Load the json string in stdout as a dictionary.
     """
     test_results, malformed = loads_partial_json(stdout, dict)
-    return {'test_group_id' : test_group_id,
-            'time' : run_time,
+    return {'time' : run_time,
             'timeout' : timeout,
             'tests' : test_results, 
             'stderr' : stderr or None,
@@ -582,7 +581,7 @@ def run_test_specs(cmd, markus_address, test_specs, test_categories, tests_path,
         if settings.get('install_data', {}).get('executable_scripts'):
             make_scripts_executable(script_files)
 
-        for test_group_id, test_data in enumerate(settings['test_data']):
+        for test_data in settings['test_data']:
             test_category = test_data.get('category', [])  
             if set(test_category) & set(test_categories): #TODO: make sure test_categories is non-string collection type
                 out, err = '', ''
@@ -616,7 +615,7 @@ def run_test_specs(cmd, markus_address, test_specs, test_categories, tests_path,
                     err = decode_if_bytes(err)
                     duration = int(round(time.time()-start, 3) * 1000)
                     extra_data = test_data.get('extra_data', {})
-                    results.append(create_test_group_result(test_group_id, out, err, duration, hooks_stderr, extra_data, timeout_expired))
+                    results.append(create_test_group_result(out, err, duration, hooks_stderr, extra_data, timeout_expired))
     return results
 
 def store_results(results_data, markus_address, assignment_id, group_id, submission_id):

--- a/testers/testers/markus_tester.py
+++ b/testers/testers/markus_tester.py
@@ -3,6 +3,7 @@ import enum
 import json
 from abc import ABC, abstractmethod
 from functools import wraps
+import traceback
 
 
 class MarkusTest(ABC):
@@ -212,9 +213,8 @@ class MarkusTest(ABC):
                 self.before_test_run()
                 result_json = run_func(self, *args, **kwargs)
                 self.after_successful_test_run()
-            except Exception as e:
-                import traceback
-                result_json = self.error(message=str(traceback.format_tb(e.__traceback__)+[str(e)]))
+            except Exception:
+                result_json = self.error(message=traceback.format_exc())
             return result_json
         return run_func_wrapper
 
@@ -266,8 +266,8 @@ class MarkusTester(ABC):
             try:
                 self.before_tester_run()
                 return run_func(self, *args, **kwargs)
-            except Exception as e:
-                print(MarkusTester.error_all(message=str(e)), flush=True)
+            except Exception:
+                print(MarkusTester.error_all(message=traceback.format_exc()), flush=True)
             finally:
                 self.after_tester_run()
         return run_func_wrapper


### PR DESCRIPTION
- report full traceback message when reporting a test or tester error
- also don't require a `test_group_id` when sending back group results to MarkUs