### PR TITLE
Update tester schema settings

### DIFF
--- a/server/autotest_server.py
+++ b/server/autotest_server.py
@@ -375,7 +375,7 @@ def test_run_command(test_username=None):
 
     return cmd
 
-def create_test_group_result(stdout, stderr, run_time, extra_data, timeout=None):
+def create_test_group_result(stdout, stderr, run_time, extra_info, timeout=None):
     """
     Return the arguments passed to this function in a dictionary. If stderr is 
     falsy, change it to None. Load the json string in stdout as a dictionary.
@@ -386,7 +386,7 @@ def create_test_group_result(stdout, stderr, run_time, extra_data, timeout=None)
             'tests' : test_results, 
             'stderr' : stderr or None,
             'malformed' :  stdout if malformed else None,
-            'extra_data': extra_data or {}}
+            'extra_info': extra_info or {}}
 
 def get_test_preexec_fn():
     """
@@ -510,7 +510,7 @@ def run_test_specs(cmd, test_specs, test_categories, tests_path, test_username, 
                             start = time.time()
                             out, err = '', ''
                             timeout_expired = None
-                            timeout = test_data.get('timeout', 30) #TODO: don't hardcode default timeout
+                            timeout = test_data.get('timeout')
                             try:
                                 proc = subprocess.Popen(args, start_new_session=True, cwd=tests_path, shell=True, 
                                                         stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE,
@@ -533,8 +533,8 @@ def run_test_specs(cmd, test_specs, test_categories, tests_path, test_username, 
                                 out = decode_if_bytes(out)
                                 err = decode_if_bytes(err)
                                 duration = int(round(time.time()-start, 3) * 1000)
-                                extra_data = test_data.get('extra_data', {})
-                                results.append(create_test_group_result(out, err, duration, extra_data, timeout_expired))
+                                extra_info = test_data.get('extra_info', {})
+                                results.append(create_test_group_result(out, err, duration, extra_info, timeout_expired))
     return results, hooks.format_errors()
 
 def store_results(results_data, markus_address, assignment_id, group_id, submission_id):

--- a/server/bin/tester_schema_skeleton.json
+++ b/server/bin/tester_schema_skeleton.json
@@ -18,14 +18,20 @@
       "oneOf": []
     }
   },
-  "title": "Test Data",
   "type": "object",
+  "required": [
+    "testers"
+  ],
   "properties": {
     "testers": {
       "type": "array",
       "minItems": 1,
       "items": {
         "type": "object",
+        "required": [
+          "tester_type",
+          "test_data"
+        ],
         "properties": {
           "tester_type": {
             "$ref": "#/definitions/installed_testers"

--- a/testers/testers/custom/markus_custom_tester.py
+++ b/testers/testers/custom/markus_custom_tester.py
@@ -8,6 +8,6 @@ class MarkusCustomTester(MarkusTester):
         super().__init__(specs, test_class=None)
 
     def run(self):
-        file_paths = self.specs.get('test_data', 'script_files', default=[])
+        file_paths = self.specs['test_data', 'script_files']
         for file_path in file_paths:
             subprocess.run(f'./{file_path}')

--- a/testers/testers/custom/specs/settings_schema.json
+++ b/testers/testers/custom/specs/settings_schema.json
@@ -11,8 +11,7 @@
       "items": {
         "type": "object",
         "required": [
-          "script_file",
-          "name",
+          "script_files",
           "timeout"
         ],
         "properties": {
@@ -26,7 +25,6 @@
           },
           "category": {
             "type": "array",
-            "minItems": 1,
             "items": {
               "$ref": "#/definitions/test_data_categories"
             },
@@ -42,10 +40,5 @@
         }
       }
     }
-  },
-  "required": [
-    "test_data",
-    "tester_type",
-    "tester_name"
-  ]
+  }
 }

--- a/testers/testers/haskell/markus_haskell_tester.py
+++ b/testers/testers/haskell/markus_haskell_tester.py
@@ -47,8 +47,8 @@ class MarkusHaskellTester(MarkusTester):
         stats_flag = "--ingredient=Test.Tasty.Stats.consoleStatsReporter"
         flags = [module_flag,
                  stats_flag,
-                 f"--timeout={self.specs.get('test_data', 'test_timeout', default=10)}s",
-                 f"--quickcheck-tests={self.specs.get('test_data', 'test_cases', default=100)}"]
+                 f"--timeout={self.specs['test_data', 'test_timeout']}s",
+                 f"--quickcheck-tests={self.specs['test_data', 'test_cases']}"]
         return flags
 
     def _parse_test_results(self, reader):
@@ -76,7 +76,7 @@ class MarkusHaskellTester(MarkusTester):
         """
         results = {}
         this_dir = os.getcwd()
-        for test_file in self.specs.get('test_data', 'script_files', default=[]):
+        for test_file in self.specs['test_data', 'script_files']:
             with tempfile.NamedTemporaryFile(dir=this_dir) as f:
                 cmd = ['tasty-discover', '.', '_', f.name] + self._test_run_flags(test_file)
                 subprocess.run(cmd, stdout=subprocess.DEVNULL, universal_newlines=True)

--- a/testers/testers/haskell/specs/settings_schema.json
+++ b/testers/testers/haskell/specs/settings_schema.json
@@ -11,8 +11,7 @@
       "items": {
         "type": "object",
         "required": [
-          "script_file",
-          "name",
+          "script_files",
           "timeout",
           "test_timeout",
           "test_cases"
@@ -28,7 +27,6 @@
           },
           "category": {
             "type": "array",
-            "minItems": 1,
             "items": {
               "$ref": "#/definitions/test_data_categories"
             },
@@ -69,10 +67,5 @@
         }
       }
     }
-  },
-  "required": [
-    "test_data",
-    "tester_type",
-    "tester_name"
-  ]
+  }
 }

--- a/testers/testers/java/markus_java_tester.py
+++ b/testers/testers/java/markus_java_tester.py
@@ -51,14 +51,14 @@ class MarkusJavaTester(MarkusTester):
 
     def compile(self):
         javac_command = ['javac', '-cp', self.java_classpath]
-        javac_command.extend(self.specs.get('test_data', 'script_files', default=[]))
+        javac_command.extend(self.specs['test_data', 'script_files'])
         # student files imported by tests will be compiled on cascade
         subprocess.run(javac_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True,
                        check=True)
 
     def run_junit(self):
         java_command = ['java', '-cp', self.java_classpath, MarkusJavaTester.JAVA_TESTER_CLASS]
-        java_command.extend(self.specs.get('test_data', 'script_files', default=[]))
+        java_command.extend(self.specs.get['test_data', 'script_files'])
         java = subprocess.run(java_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
                               check=True)
         return java

--- a/testers/testers/java/specs/settings_schema.json
+++ b/testers/testers/java/specs/settings_schema.json
@@ -11,8 +11,7 @@
       "items": {
         "type": "object",
         "required": [
-          "script_file",
-          "name",
+          "script_files",
           "timeout"
         ],
         "properties": {
@@ -26,7 +25,6 @@
           },
           "category": {
             "type": "array",
-            "minItems": 1,
             "items": {
               "$ref": "#/definitions/test_data_categories"
             },
@@ -59,10 +57,5 @@
         }
       }
     }
-  },
-  "required": [
-    "test_data",
-    "tester_type",
-    "tester_name"
-  ]
+  }
 }

--- a/testers/testers/py/markus_python_tester.py
+++ b/testers/testers/py/markus_python_tester.py
@@ -127,7 +127,7 @@ class MarkusPythonTester(MarkusTester):
         test_suite = self._load_unittest_tests(test_file)
         with open(os.devnull, 'w') as nullstream:    
             test_runner = unittest.TextTestRunner(
-                verbosity=self.specs.get('test_data', 'output_verbosity', default=2),
+                verbosity=self.specs['test_data', 'output_verbosity'],
                 stream=nullstream,
                 resultclass=MarkusTextTestResults)
             test_result = test_runner.run(test_suite)
@@ -143,7 +143,7 @@ class MarkusPythonTester(MarkusTester):
         with open(os.devnull, 'w') as null_out:
             try:
                 sys.stdout = null_out
-                verbosity = self.specs.get('test_data', 'output_verbosity', default='short')
+                verbosity = self.specs['test_data', 'output_verbosity']
                 with tempfile.NamedTemporaryFile(mode="w+", dir=this_dir) as sf:
                     pytest.main([test_file, f'--junitxml={sf.name}', f'--tb={verbosity}'],
                                 plugins=[AddDocstringToJunitXMLPlugin()])
@@ -157,8 +157,8 @@ class MarkusPythonTester(MarkusTester):
         Return a dict mapping each filename to its results
         """
         results = {}
-        for test_file in self.specs.get('test_data', 'script_files', default=[]):
-            if self.specs.get('test_data', 'tester') == 'unittest':
+        for test_file in self.specs['test_data', 'script_files']:
+            if self.specs['test_data', 'tester'] == 'unittest':
                 result = self._run_unittest_tests(test_file)
             else:
                 result = self._run_pytest_tests(test_file)

--- a/testers/testers/py/specs/settings_schema.json
+++ b/testers/testers/py/specs/settings_schema.json
@@ -1,4 +1,7 @@
 {
+  "required": [
+    "env_data"
+  ],
   "properties": {
     "tester_type": {
       "enum": [
@@ -7,6 +10,9 @@
     },
     "env_data": {
       "type": "object",
+      "required": [
+        "python_version"
+      ],
       "properties": {
         "python_version": {
           "type": "string",
@@ -27,9 +33,7 @@
       "items": {
         "type": "object",
         "required": [
-          "script_file",
-          "environment",
-          "name",
+          "script_files",
           "timeout",
           "tester",
           "output_verbosity"
@@ -45,7 +49,6 @@
           },
           "category": {
             "type": "array",
-            "minItems": 1,
             "items": {
               "$ref": "#/definitions/test_data_categories"
             },
@@ -129,10 +132,5 @@
         }
       }
     }
-  },
-  "required": [
-    "test_data",
-    "tester_type",
-    "tester_name"
-  ]
+  }
 }

--- a/testers/testers/pyta/markus_pyta_tester.py
+++ b/testers/testers/pyta/markus_pyta_tester.py
@@ -118,8 +118,7 @@ class MarkusPyTATester(MarkusTester):
 
     @MarkusTester.run_decorator
     def run(self):
-        feedback_file = self.specs.get('test_data', 'feedback_file_name')
-        with MarkusTester.open_feedback(feedback_file) as feedback_open:
+        with MarkusTester.open_feedback(self.feedback_file) as feedback_open:
             for test_data in self.specs.get('test_data', 'student_files', default=[]):
                 student_file_path = test_data['file_path']
                 max_points = test_data.get('max_points', 10)

--- a/testers/testers/pyta/specs/settings_schema.json
+++ b/testers/testers/pyta/specs/settings_schema.json
@@ -1,4 +1,7 @@
 {
+  "required": [
+    "env_data"
+  ],
   "properties": {
     "tester_type": {
       "enum": [
@@ -7,6 +10,9 @@
     },
     "env_data": {
       "type": "object",
+      "required": [
+        "python_version"
+      ],
       "properties": {
         "python_version": {
           "type": "string",
@@ -27,8 +33,7 @@
       "items": {
         "type": "object",
         "required": [
-          "student_file",
-          "name",
+          "student_files",
           "timeout"
         ],
         "properties": {
@@ -90,10 +95,5 @@
         }
       }
     }
-  },
-  "required": [
-    "test_data",
-    "tester_type",
-    "tester_name"
-  ]
+  }
 }

--- a/testers/testers/racket/markus_racket_tester.py
+++ b/testers/testers/racket/markus_racket_tester.py
@@ -41,7 +41,7 @@ class MarkusRacketTester(MarkusTester):
         """
         results = {}
         markus_rkt = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'lib', 'markus.rkt')
-        for group in self.specs.get('test_data', 'script_files', default=[]):
+        for group in self.specs['test_data', 'script_files']:
             test_file = group.get('script_file')
             if test_file:
                 suite_name = group.get('test_suite_name', 'all-tests')

--- a/testers/testers/racket/specs/settings_schema.json
+++ b/testers/testers/racket/specs/settings_schema.json
@@ -11,8 +11,7 @@
       "items": {
         "type": "object",
         "required": [
-          "student_file",
-          "name",
+          "script_files",
           "timeout"
         ],
         "properties": {
@@ -67,10 +66,5 @@
         }
       }
     }
-  },
-  "required": [
-    "test_data",
-    "tester_type",
-    "tester_name"
-  ]
+  }
 }


### PR DESCRIPTION
- use `extra_info` exclusively (not `extra_data`)
- update the tester schemas to be consistent (don't require keys that aren't there, set defaults where necessary, etc.)

This is a companion PR to #182 because it sets the defaults.
This should be tested with https://github.com/MarkUsProject/Markus/pull/3954