### PR TITLE
flake8 config

### DIFF
--- a/.flake8.ini
+++ b/.flake8.ini
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,4 @@
 flake8:
   enabled: true
+  config_file: .flake8.ini
 


### PR DESCRIPTION
- add config file for flake8 (used by houndci)
- see [here](http://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-max-line-length) for more possible config options 
