### PR TITLE
Feedback file context manager interface simplification

### DIFF
--- a/testers/testers/haskell/markus_haskell_tester.py
+++ b/testers/testers/haskell/markus_haskell_tester.py
@@ -93,8 +93,7 @@ class MarkusHaskellTester(MarkusTester):
         except subprocess.CalledProcessError as e:
             msg = (e.stdout or '' + e.stderr or '') or str(e)
             raise type(e)(msg) from e
-        feedback_file = self.specs.get('test_data', 'feedback_file_name')
-        with MarkusTester.open_feedback(feedback_file) as feedback_open:
+        with self.open_feedback() as feedback_open:
             for test_file, result in results.items():
                 if result['stderr']:
                     raise Exception(result['stderr'])

--- a/testers/testers/java/markus_java_tester.py
+++ b/testers/testers/java/markus_java_tester.py
@@ -79,8 +79,7 @@ class MarkusJavaTester(MarkusTester):
         except subprocess.CalledProcessError as e:
             msg = MarkusJavaTest.ERRORS['bad_java'].format(e.stdout + e.stderr)
             raise type(e)(msg) from e
-        feedback_file = self.specs.get('test_data', 'feedback_file_name')
-        with MarkusTester.open_feedback(feedback_file) as feedback_open:
+        with self.open_feedback() as feedback_open:
             for result in json.loads(results.stdout):
                 test = self.test_class(self, result, feedback_open)
                 result_json = test.run()

--- a/testers/testers/jdbc/markus_jdbc_tester.py
+++ b/testers/testers/jdbc/markus_jdbc_tester.py
@@ -119,8 +119,7 @@ class MarkusJDBCTester(MarkusSQLTester):
         except subprocess.CalledProcessError as e:
             msg = MarkusJDBCTest.ERROR_MSGS['bad_javac'].format(e.stdout)
             raise type(e)(msg) from e
-        feedback_file = self.specs.get('test_data', 'feedback_file_name')
-        with MarkusTester.open_feedback(feedback_file) as feedback_open:
+        with self.open_feedback() as feedback_open:
             class_groups = self.specs['test_data', 'class_files']
             test_kwargs = []
             env_name = os.path.basename(self.specs['env_loc'])

--- a/testers/testers/markus_tester.py
+++ b/testers/testers/markus_tester.py
@@ -272,9 +272,20 @@ class MarkusTester(ABC):
                 self.after_tester_run()
         return run_func_wrapper
 
-    @staticmethod
     @contextmanager
-    def open_feedback(filename, mode='w'):
+    def open_feedback(self, filename=None, no_feedback=False, mode='w'):
+        """
+        Yields an open file object, opened in <mode> mode if it exists,
+        otherwise it yields None.
+
+        If <filename> is None, the feedback_file_name from self.specs is
+        used unless <no_feedback> is True in which case this method yields
+        None.
+        """
+        if no_feedback:
+            yield None
+        if filename is None:
+            filename = self.specs.get('test_data', 'feedback_file_name')
         if filename:
             feedback_open = open(filename, mode)
             try:

--- a/testers/testers/markus_tester.py
+++ b/testers/testers/markus_tester.py
@@ -273,7 +273,7 @@ class MarkusTester(ABC):
         return run_func_wrapper
 
     @contextmanager
-    def open_feedback(self, filename=None, no_feedback=False, mode='w'):
+    def open_feedback(self, filename=None, mode='w'):
         """
         Yields an open file object, opened in <mode> mode if it exists,
         otherwise it yields None.

--- a/testers/testers/markus_tester.py
+++ b/testers/testers/markus_tester.py
@@ -279,11 +279,8 @@ class MarkusTester(ABC):
         otherwise it yields None.
 
         If <filename> is None, the feedback_file_name from self.specs is
-        used unless <no_feedback> is True in which case this method yields
-        None.
+        used.
         """
-        if no_feedback:
-            yield None
         if filename is None:
             filename = self.specs.get('test_data', 'feedback_file_name')
         if filename:

--- a/testers/testers/py/markus_python_tester.py
+++ b/testers/testers/py/markus_python_tester.py
@@ -168,8 +168,7 @@ class MarkusPythonTester(MarkusTester):
     @MarkusTester.run_decorator
     def run(self):
         results = self.run_python_tests()
-        feedback_file = self.specs.get('test_data', 'feedback_file_name')
-        with MarkusTester.open_feedback(feedback_file) as feedback_open:
+        with self.open_feedback() as feedback_open:
             for test_file, result in results.items():
                 for res in result:
                     test = self.test_class(self, test_file, res, feedback_open)

--- a/testers/testers/pyta/markus_pyta_tester.py
+++ b/testers/testers/pyta/markus_pyta_tester.py
@@ -118,7 +118,7 @@ class MarkusPyTATester(MarkusTester):
 
     @MarkusTester.run_decorator
     def run(self):
-        with MarkusTester.open_feedback(self.feedback_file) as feedback_open:
+        with self.open_feedback(self.feedback_file) as feedback_open:
             for test_data in self.specs.get('test_data', 'student_files', default=[]):
                 student_file_path = test_data['file_path']
                 max_points = test_data.get('max_points', 10)

--- a/testers/testers/racket/markus_racket_tester.py
+++ b/testers/testers/racket/markus_racket_tester.py
@@ -57,8 +57,7 @@ class MarkusRacketTester(MarkusTester):
         except subprocess.CalledProcessError as e:
             msg = e.stdout + e.stderr
             raise type(e)(msg) from e
-        feedback_file = self.specs.get('test_data', 'feedback_file_name')
-        with MarkusTester.open_feedback(feedback_file) as feedback_open:
+        with self.open_feedback() as feedback_open:
             for test_file, result in results.items():
                 if result.strip():
                     try:

--- a/testers/testers/sql/markus_sql_tester.py
+++ b/testers/testers/sql/markus_sql_tester.py
@@ -263,8 +263,7 @@ class MarkusSQLTester(MarkusTester):
 
     @MarkusTester.run_decorator
     def run(self):
-        feedback_file = self.specs.get('test_data', 'feedback_file_name')
-        with MarkusTester.open_feedback(feedback_file) as feedback_open:
+        with self.open_feedback() as feedback_open:
             query_groups = self.specs.get('test_data', 'query_files', default=[])
             env_name = os.path.basename(self.specs['env_loc'])
             for group in query_groups:


### PR DESCRIPTION
- this simplifies the default interface to the `open_feedback` context manager so that you don't have to pass in the filename of your feedback file every time. 