### PR TITLE
Don't print full traceback if the error is expected

### DIFF
--- a/testers/testers/haskell/markus_haskell_tester.py
+++ b/testers/testers/haskell/markus_haskell_tester.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import csv
 
-from testers.markus_tester import MarkusTester, MarkusTest
+from testers.markus_tester import MarkusTester, MarkusTest, MarkusTestError
 
 class MarkusHaskellTest(MarkusTest):
 
@@ -92,11 +92,11 @@ class MarkusHaskellTester(MarkusTester):
             results = self.run_haskell_tests()
         except subprocess.CalledProcessError as e:
             msg = (e.stdout or '' + e.stderr or '') or str(e)
-            raise type(e)(msg) from e
+            raise MarkusTestError(msg) from e
         with self.open_feedback() as feedback_open:
             for test_file, result in results.items():
                 if result['stderr']:
-                    raise Exception(result['stderr'])
+                    raise MarkusTestError(result['stderr'])
                 for res in result['results']:
                     test = self.test_class(self, test_file, res, feedback_open)
                     print(test.run(), flush=True)

--- a/testers/testers/java/markus_java_tester.py
+++ b/testers/testers/java/markus_java_tester.py
@@ -2,7 +2,7 @@ import enum
 import json
 import subprocess
 
-from testers.markus_tester import MarkusTester, MarkusTest
+from testers.markus_tester import MarkusTester, MarkusTest, MarkusTestError
 
 
 class MarkusJavaTest(MarkusTest):
@@ -70,15 +70,15 @@ class MarkusJavaTester(MarkusTester):
             self.compile()
         except subprocess.CalledProcessError as e:
             msg = MarkusJavaTest.ERRORS['bad_javac'].format(e.stdout)
-            raise type(e)(msg) from e
+            raise MarkusTestError(msg) from e
         # run the tests with junit
         try:
             results = self.run_junit()
             if results.stderr:
-                raise Exception(results.stderr)
+                raise MarkusTestError(results.stderr)
         except subprocess.CalledProcessError as e:
             msg = MarkusJavaTest.ERRORS['bad_java'].format(e.stdout + e.stderr)
-            raise type(e)(msg) from e
+            raise MarkusTestError(msg) from e
         with self.open_feedback() as feedback_open:
             for result in json.loads(results.stdout):
                 test = self.test_class(self, result, feedback_open)

--- a/testers/testers/jdbc/markus_jdbc_tester.py
+++ b/testers/testers/jdbc/markus_jdbc_tester.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 
 from testers.sql.markus_sql_tester import MarkusSQLTester, MarkusSQLTest
-from testers.markus_tester import MarkusTester, MarkusTest
+from testers.markus_tester import MarkusTester, MarkusTest, MarkusTestError
 
 
 class MarkusJDBCTest(MarkusSQLTest):
@@ -55,14 +55,12 @@ class MarkusJDBCTest(MarkusSQLTest):
                 return self.failed(message=java.stderr)
             if java.stdout == MarkusTest.Status.ERROR.value:
                 return self.error(message=java.stderr)
-        except Exception as e:
+        except subprocess.CalledProcessError as e:
+            msg = self.ERROR_MSGS['bad_java'].format(e.stdout + e.stderr)
+            raise MarkusTestError(msg)            
+        finally:
             self.tester.oracle_connection.commit()
             self.tester.test_connection.commit()
-            if isinstance(e, subprocess.CalledProcessError):
-                msg = self.ERROR_MSGS['bad_java'].format(e.stdout + e.stderr)
-            else:
-                msg = str(e)
-            return self.error(message=msg)
         points_earned = self.java_points
         # fetch and compare sql table results
         messages = []
@@ -112,13 +110,13 @@ class MarkusJDBCTester(MarkusSQLTester):
         for java_file in self.java_files:
             if not os.path.isfile(java_file):
                 msg = MarkusJDBCTest.ERROR_MSGS['no_submission'].format(java_file)
-                raise Exception(msg)
+                raise MarkusTestError(msg)
         # check that the submission compiles
         try:
             self.init_java()
         except subprocess.CalledProcessError as e:
             msg = MarkusJDBCTest.ERROR_MSGS['bad_javac'].format(e.stdout)
-            raise type(e)(msg) from e
+            raise MarkusTestError(msg) from e
         with self.open_feedback() as feedback_open:
             class_groups = self.specs['test_data', 'class_files']
             test_kwargs = []

--- a/testers/testers/jdbc/markus_jdbc_tester.py
+++ b/testers/testers/jdbc/markus_jdbc_tester.py
@@ -57,7 +57,7 @@ class MarkusJDBCTest(MarkusSQLTest):
                 return self.error(message=java.stderr)
         except subprocess.CalledProcessError as e:
             msg = self.ERROR_MSGS['bad_java'].format(e.stdout + e.stderr)
-            raise MarkusTestError(msg)            
+            raise MarkusTestError(msg)
         finally:
             self.tester.oracle_connection.commit()
             self.tester.test_connection.commit()

--- a/testers/testers/markus_tester.py
+++ b/testers/testers/markus_tester.py
@@ -6,6 +6,8 @@ from functools import wraps
 import traceback
 
 
+class MarkusTestError(Exception): pass
+
 class MarkusTest(ABC):
 
     class Status(enum.Enum):
@@ -205,6 +207,12 @@ class MarkusTest(ABC):
 
     @staticmethod
     def run_decorator(run_func):
+        """
+        Wrapper around a test.run method. Used to print error messages
+        in the correct json format. If it catches a MarkusTestError then
+        only the error message is sent in the description, otherwise the
+        whole traceback is sent. 
+        """
         @wraps(run_func)
         def run_func_wrapper(self, *args, **kwargs):
             try:
@@ -213,6 +221,8 @@ class MarkusTest(ABC):
                 self.before_test_run()
                 result_json = run_func(self, *args, **kwargs)
                 self.after_successful_test_run()
+            except MarkusTestError as e:
+                result_json = self.error(message=str(e))
             except Exception:
                 result_json = self.error(message=traceback.format_exc())
             return result_json
@@ -261,11 +271,19 @@ class MarkusTester(ABC):
 
     @staticmethod
     def run_decorator(run_func):
+        """
+        Wrapper around a tester.run method. Used to print error messages
+        in the correct json format. If it catches a MarkusTestError then
+        only the error message is sent in the description, otherwise the
+        whole traceback is sent.
+        """
         @wraps(run_func)
         def run_func_wrapper(self, *args, **kwargs):
             try:
                 self.before_tester_run()
                 return run_func(self, *args, **kwargs)
+            except MarkusTestError as e:
+                print(MarkusTester.error_all(message=str(e)), flush=True)
             except Exception:
                 print(MarkusTester.error_all(message=traceback.format_exc()), flush=True)
             finally:

--- a/testers/testers/markus_tester.py
+++ b/testers/testers/markus_tester.py
@@ -6,7 +6,8 @@ from functools import wraps
 import traceback
 
 
-class MarkusTestError(Exception): pass
+class MarkusTestError(Exception):
+    pass
 
 class MarkusTest(ABC):
 
@@ -211,7 +212,7 @@ class MarkusTest(ABC):
         Wrapper around a test.run method. Used to print error messages
         in the correct json format. If it catches a MarkusTestError then
         only the error message is sent in the description, otherwise the
-        whole traceback is sent. 
+        whole traceback is sent.
         """
         @wraps(run_func)
         def run_func_wrapper(self, *args, **kwargs):

--- a/testers/testers/racket/markus_racket_tester.py
+++ b/testers/testers/racket/markus_racket_tester.py
@@ -2,7 +2,7 @@ import json
 import subprocess
 import os
 
-from testers.markus_tester import MarkusTester, MarkusTest
+from testers.markus_tester import MarkusTester, MarkusTest, MarkusTestError
 
 
 class MarkusRacketTest(MarkusTest):
@@ -56,7 +56,7 @@ class MarkusRacketTester(MarkusTester):
             results = self.run_racket_test()
         except subprocess.CalledProcessError as e:
             msg = e.stdout + e.stderr
-            raise type(e)(msg) from e
+            raise MarkusTestError(msg) from e
         with self.open_feedback() as feedback_open:
             for test_file, result in results.items():
                 if result.strip():
@@ -64,7 +64,7 @@ class MarkusRacketTester(MarkusTester):
                         test_results = json.loads(result)
                     except json.JSONDecodeError as e:
                         msg = MarkusRacketTester.ERROR_MSGS['bad_json'].format(result)
-                        raise type(e)(msg) from e
+                        raise MarkusTestError(msg) from e
                     for t_result in test_results:
                         test = self.test_class(self, feedback_open, t_result)
                         print(test.run(), flush=True)

--- a/testers/testers/sql/markus_sql_tester.py
+++ b/testers/testers/sql/markus_sql_tester.py
@@ -215,11 +215,9 @@ class MarkusSQLTest(MarkusTest):
             else:
                 oracle_solution, test_solution = self.get_psql_dump(self.query_name, test_order_file)
                 return self.failed(message, oracle_solution, test_solution)
-        except Exception as e:
+        finally:
             self.tester.oracle_connection.commit()
             self.tester.test_connection.commit()
-            import traceback
-            return self.error(message=str(traceback.format_tb(e.__traceback__)+[str(e)]))
 
 
 class MarkusSQLTester(MarkusTester):


### PR DESCRIPTION
- this makes sure that only the relevant information is communicated in the test results
- the only time a traceback should be included in the results is if the error is an error in the markus-autotesting code, not in the test scripts, student files, etc.

Closes #193