### PR TITLE
Java update to jdk-11

### DIFF
--- a/testers/testers/java/bin/install.sh
+++ b/testers/testers/java/bin/install.sh
@@ -4,7 +4,7 @@ set -e
 
 install_packages() {
     echo "[JAVA-INSTALL] Installing system packages"
-    sudo apt-get install python3 openjdk-8-jdk jq
+    sudo apt-get install python3 openjdk-11-jdk jq
 }
 
 compile_tester() {

--- a/testers/testers/java/bin/install.sh
+++ b/testers/testers/java/bin/install.sh
@@ -4,7 +4,7 @@ set -e
 
 install_packages() {
     echo "[JAVA-INSTALL] Installing system packages"
-    sudo apt-get install python3 openjdk-11-jdk jq
+    sudo apt-get install python3 openjdk-8-jdk jq
 }
 
 compile_tester() {

--- a/testers/testers/java/bin/uninstall.sh
+++ b/testers/testers/java/bin/uninstall.sh
@@ -26,5 +26,5 @@ JAVADIR=${TESTERDIR}/lib
 # main
 remove_tester
 reset_specs
-echo "[JAVA-UNINSTALL] The following system packages have not been uninstalled: python3 openjdk-11-jdk jq. You may uninstall them if you wish."
+echo "[JAVA-UNINSTALL] The following system packages have not been uninstalled: python3 openjdk-12-jdk jq. You may uninstall them if you wish."
 rm -f ${SPECSDIR}/.installed

--- a/testers/testers/java/bin/uninstall.sh
+++ b/testers/testers/java/bin/uninstall.sh
@@ -26,5 +26,5 @@ JAVADIR=${TESTERDIR}/lib
 # main
 remove_tester
 reset_specs
-echo "[JAVA-UNINSTALL] The following system packages have not been uninstalled: python3 openjdk-12-jdk jq. You may uninstall them if you wish."
+echo "[JAVA-UNINSTALL] The following system packages have not been uninstalled: python3 openjdk-11-jdk jq. You may uninstall them if you wish."
 rm -f ${SPECSDIR}/.installed

--- a/testers/testers/java/lib/build.gradle
+++ b/testers/testers/java/lib/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'application'
 
 group = 'edu.toronto.cs.teach'
 version = '1.7.1'
-sourceCompatibility = 1.8
+sourceCompatibility = 11.0
 mainClassName = 'edu.toronto.cs.teach.MarkusJavaTester'
 
 repositories {

--- a/testers/testers/jdbc/bin/install.sh
+++ b/testers/testers/jdbc/bin/install.sh
@@ -4,7 +4,7 @@ set -e
 
 install_packages() {
     echo "[JDBC-INSTALL] Installing system packages"
-    sudo apt-get install python3 openjdk-8-jdk jq
+    sudo apt-get install python3 openjdk-11-jdk jq
 }
 
 install_sql_tester() {

--- a/testers/testers/jdbc/bin/install.sh
+++ b/testers/testers/jdbc/bin/install.sh
@@ -4,7 +4,7 @@ set -e
 
 install_packages() {
     echo "[JDBC-INSTALL] Installing system packages"
-    sudo apt-get install python3 openjdk-11-jdk jq
+    sudo apt-get install python3 openjdk-8-jdk jq
 }
 
 install_sql_tester() {

--- a/testers/testers/jdbc/bin/uninstall.sh
+++ b/testers/testers/jdbc/bin/uninstall.sh
@@ -18,6 +18,6 @@ SPECSDIR=${TESTERDIR}/specs
 
 # main
 reset_specs
-echo "[JDBC-UNINSTALL] The following system packages have not been uninstalled: python3 openjdk-11-jdk. You may uninstall them if you wish."
+echo "[JDBC-UNINSTALL] The following system packages have not been uninstalled: python3 openjdk-12-jdk. You may uninstall them if you wish."
 echo "[JDBC-UNINSTALL] The JDBC tester also installs the SQL tester. To remove the SQL tester as well run the uninstall.sh script in the sql/bin directory."
 rm -f ${SPECSDIR}/.installed

--- a/testers/testers/jdbc/bin/uninstall.sh
+++ b/testers/testers/jdbc/bin/uninstall.sh
@@ -18,6 +18,6 @@ SPECSDIR=${TESTERDIR}/specs
 
 # main
 reset_specs
-echo "[JDBC-UNINSTALL] The following system packages have not been uninstalled: python3 openjdk-12-jdk. You may uninstall them if you wish."
+echo "[JDBC-UNINSTALL] The following system packages have not been uninstalled: python3 openjdk-11-jdk. You may uninstall them if you wish."
 echo "[JDBC-UNINSTALL] The JDBC tester also installs the SQL tester. To remove the SQL tester as well run the uninstall.sh script in the sql/bin directory."
 rm -f ${SPECSDIR}/.installed


### PR DESCRIPTION
- updates java version to jdk-11 (jdk-11 is available without a ppa on ubuntu 18.04)
- should be pulled in after #198 

Closes #197