### PR TITLE
Fix java hang on install

### DIFF
--- a/testers/testers/java/lib/gradlew
+++ b/testers/testers/java/lib/gradlew
@@ -44,7 +44,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+DEFAULT_JVM_OPTS=''
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"


### PR DESCRIPTION
By setting the maximum/minimum heap size for JVM, the `./gradlew installDist --no-daemon` command in the java tester install script hangs.

It doesn't hang if the maximum heap size is increased to something like:

```
DEFAULT_JVM_OPTS='"-Xmx128m" "-Xms128m"'
```

but I think it's probably safest if we just stick with the [defaults](https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:how_much_memory_does_the_daemon_use_and_can_i_give_it_more)