### PR TITLE
Make sure postgres uses tcp port

### DIFF
--- a/server/autotest_server.py
+++ b/server/autotest_server.py
@@ -501,7 +501,7 @@ def setup_database(test_username):
     with open(PGPASSFILE) as f:
         password = f.read().strip()
 
-    with psycopg2.connect(database=database, user=user, password=password) as conn:
+    with psycopg2.connect(database=database, user=user, password=password, host='localhost') as conn:
         with conn.cursor() as cursor:
             cursor.execute("DROP OWNED BY CURRENT_USER;")
             if test_username != user:


### PR DESCRIPTION
- not specifying a hostname (even if we specify `localhost`) means that postgres/psycopg2 will try to connect to the database using the unix-domain socket apparently.
- this can cause issues if postgres is not set to listen on the socket