### PR TITLE
Fix pytest version to before the junitxml output file format was changed

### DIFF
--- a/testers/testers/py/bin/create_environment.sh
+++ b/testers/testers/py/bin/create_environment.sh
@@ -23,7 +23,7 @@ SETTINGS_JSON=$1
 
 ENV_DIR=$(echo ${SETTINGS_JSON} | jq --raw-output .env_loc)
 PY_VERSION=$(echo ${SETTINGS_JSON} | jq --raw-output .env_data.python_version)
-PIP_REQUIREMENTS="pytest psycopg2-binary $(echo ${SETTINGS_JSON} | jq --raw-output .env_data.pip_requirements)"
+PIP_REQUIREMENTS="pytest==5.0.0 psycopg2-binary $(echo ${SETTINGS_JSON} | jq --raw-output .env_data.pip_requirements)"
 
 VENV_DIR=${ENV_DIR}/venv
 THIS_SCRIPT=$(readlink -f ${BASH_SOURCE})


### PR DESCRIPTION
- this will be handled differently on the master branch (use the latest version of pytest and update the way we parse the junitxml file). 