### PR TITLE
Remove service queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,6 @@ A list of dictionaries containing the following keys/value pairs:
 - `'filter'`: a function which takes the same keyword arguments as the `run_test` function in `autotest_enqueuer.py` and returns `True` if this queue should be used to schedule the test job
 See `config.py` for more details and to see defaults.
 
-##### SERVICE_QUEUE
-A string representing the name of the queue on which to enqueue service jobs (ie. jobs that don't involve running a test). 
-This string should have a different name than any of the worker queues (see above).
-Default: `'service'`
-
 ##### WORKERS
 A list of tuples indicating the priority in which order a worker user should pop jobs off the end of each queue.
 Each tuple contains an integer indicating the number of worker users who should respect this priority order, followed by a list containing the names of queues in priority order.

--- a/server/autotest_enqueuer.py
+++ b/server/autotest_enqueuer.py
@@ -131,7 +131,7 @@ def update_specs(test_specs, schema=None, **kw):
         errors = list(form_validation.validate_with_defaults(schema, test_specs))
         if errors:
             raise form_validation.best_match(errors)
-    ats.update_test_specs(test_specs = test_specs, **kw)
+    ats.update_test_specs(test_specs=test_specs, **kw)
  
 def cancel_test(markus_address, run_ids, **kw):
     """

--- a/server/autotest_enqueuer.py
+++ b/server/autotest_enqueuer.py
@@ -125,15 +125,13 @@ def run_test(user_type, batch_id, **kw):
 @clean_on_error
 def update_specs(test_specs, schema=None, **kw):
     """
-    Enqueue a test specs update job with keyword arguments specified in **kw
+    Run test spec update function after validating the <schema> form data.
     """
-    queue = rq.Queue(config.SERVICE_QUEUE, connection=ats.redis_connection())
-    check_args(ats.update_test_specs, kwargs={'test_specs': test_specs, **kw})
     if schema is not None:
         errors = list(form_validation.validate_with_defaults(schema, test_specs))
         if errors:
             raise form_validation.best_match(errors)
-    queue.enqueue_call(ats.update_test_specs, kwargs={'test_specs': test_specs, **kw})
+    ats.update_test_specs(test_specs = test_specs, **kw)
  
 def cancel_test(markus_address, run_ids, **kw):
     """

--- a/server/config.py
+++ b/server/config.py
@@ -77,11 +77,8 @@ single_queue = {'name': 'single', 'filter': single_filter}
 student_queue = {'name': 'student', 'filter': student_filter}
 WORKER_QUEUES = [batch_queue, single_queue, student_queue]
 
-# name of the service queue
-SERVICE_QUEUE = 'service'
-
 ### WORKER CONFIGS ###
 
-WORKERS = [(4, [SERVICE_QUEUE, student_queue['name'], single_queue['name'], batch_queue['name']]),
-           (2, [SERVICE_QUEUE, single_queue['name'], student_queue['name'], batch_queue['name']]),
-           (2, [SERVICE_QUEUE, batch_queue['name'], student_queue['name'], single_queue['name']])]
+WORKERS = [(4, [student_queue['name'], single_queue['name'], batch_queue['name']]),
+           (2, [single_queue['name'], student_queue['name'], batch_queue['name']]),
+           (2, [batch_queue['name'], student_queue['name'], single_queue['name']])]


### PR DESCRIPTION
This enables better reporting of errors back to MarkUs during test script updates and test cancelation 