### PR TITLE
Differentiate between expected and unexpected tester errors

### DIFF
--- a/testers/testers/custom/markus_custom_tester.py
+++ b/testers/testers/custom/markus_custom_tester.py
@@ -7,6 +7,7 @@ class MarkusCustomTester(MarkusTester):
     def __init__(self, specs):
         super().__init__(specs, test_class=None)
 
+    @MarkusTester.run_decorator
     def run(self):
         file_paths = self.specs['test_data', 'script_files']
         for file_path in file_paths:

--- a/testers/testers/haskell/markus_haskell_tester.py
+++ b/testers/testers/haskell/markus_haskell_tester.py
@@ -8,7 +8,7 @@ from testers.markus_tester import MarkusTester, MarkusTest, MarkusTestError
 class MarkusHaskellTest(MarkusTest):
 
     def __init__(self, tester, test_file, result, feedback_open=None):
-        self._test_name = result['name']
+        self._test_name = result.get('name')
         self._file_name = test_file
         self.status = result['status']
         self.message = result['description']
@@ -16,7 +16,9 @@ class MarkusHaskellTest(MarkusTest):
 
     @property
     def test_name(self):
-        return '.'.join([self._file_name, self._test_name])
+        if self._test_name:
+            return '.'.join([self._file_name, self._test_name])
+        return self._file_name
 
     @MarkusTest.run_decorator
     def run(self):
@@ -68,8 +70,7 @@ class MarkusHaskellTester(MarkusTester):
 
     def run_haskell_tests(self):
         """
-        Return test results for each test file. Results contain a list of parsed test results and the 
-        output of stderr from running the tests. 
+        Return test results for each test file. Results contain a list of parsed test results 
 
         Tests are run by first discovering all tests from a specific module (using tasty-discover)
         and then running all the discovered tests and parsing the results from a csv file.
@@ -79,11 +80,11 @@ class MarkusHaskellTester(MarkusTester):
         for test_file in self.specs['test_data', 'script_files']:
             with tempfile.NamedTemporaryFile(dir=this_dir) as f:
                 cmd = ['tasty-discover', '.', '_', f.name] + self._test_run_flags(test_file)
-                subprocess.run(cmd, stdout=subprocess.DEVNULL, universal_newlines=True)
+                subprocess.run(cmd, stdout=subprocess.DEVNULL, universal_newlines=True, check=True)
                 with tempfile.NamedTemporaryFile(mode="w+", dir=this_dir) as sf:
                     cmd = ['runghc', f.name, f"--stats={sf.name}"]
-                    test_proc = subprocess.run(cmd, stdout=subprocess.DEVNULL, universal_newlines=True)
-                    results[test_file] = {'stderr':test_proc.stderr, 'results':self._parse_test_results(csv.reader(sf))}
+                    test_proc = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, universal_newlines=True, check=True)
+                    results[test_file] = self._parse_test_results(csv.reader(sf))
         return results
 
     @MarkusTester.run_decorator
@@ -91,12 +92,9 @@ class MarkusHaskellTester(MarkusTester):
         try:
             results = self.run_haskell_tests()
         except subprocess.CalledProcessError as e:
-            msg = (e.stdout or '' + e.stderr or '') or str(e)
-            raise MarkusTestError(msg) from e
+            raise MarkusTestError(e.stderr) from e
         with self.open_feedback() as feedback_open:
             for test_file, result in results.items():
-                if result['stderr']:
-                    raise MarkusTestError(result['stderr'])
-                for res in result['results']:
+                for res in result:
                     test = self.test_class(self, test_file, res, feedback_open)
                     print(test.run(), flush=True)

--- a/testers/testers/haskell/markus_haskell_tester.py
+++ b/testers/testers/haskell/markus_haskell_tester.py
@@ -70,7 +70,7 @@ class MarkusHaskellTester(MarkusTester):
 
     def run_haskell_tests(self):
         """
-        Return test results for each test file. Results contain a list of parsed test results 
+        Return test results for each test file. Results contain a list of parsed test results.
 
         Tests are run by first discovering all tests from a specific module (using tasty-discover)
         and then running all the discovered tests and parsing the results from a csv file.
@@ -83,7 +83,11 @@ class MarkusHaskellTester(MarkusTester):
                 subprocess.run(cmd, stdout=subprocess.DEVNULL, universal_newlines=True, check=True)
                 with tempfile.NamedTemporaryFile(mode="w+", dir=this_dir) as sf:
                     cmd = ['runghc', f.name, f"--stats={sf.name}"]
-                    test_proc = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, universal_newlines=True, check=True)
+                    subprocess.run(cmd,
+                                   stdout=subprocess.DEVNULL,
+                                   stderr=subprocess.PIPE,
+                                   universal_newlines=True,
+                                   check=True)
                     results[test_file] = self._parse_test_results(csv.reader(sf))
         return results
 

--- a/testers/testers/markus_tester.py
+++ b/testers/testers/markus_tester.py
@@ -246,14 +246,15 @@ class MarkusTester(ABC):
         self.test_class = test_class
 
     @staticmethod
-    def error_all(message, points_total=0):
+    def error_all(message, points_total=0, expected=False):
         """
         Err all tests of this tester with a single message.
         :param message: The error message.
         :param points_total: The total points the tests could earn, must be a float >= 0.
         :return The formatted erred tests.
         """
-        return MarkusTest.format_result(test_name='All tests', status=MarkusTest.Status.ERROR_ALL, output=message,
+        status = MarkusTest.Status.ERROR if expected else MarkusTest.Status.ERROR_ALL
+        return MarkusTest.format_result(test_name='All tests', status=status, output=message,
                                         points_earned=0, points_total=points_total)
 
     def before_tester_run(self):
@@ -284,7 +285,7 @@ class MarkusTester(ABC):
                 self.before_tester_run()
                 return run_func(self, *args, **kwargs)
             except MarkusTestError as e:
-                print(MarkusTester.error_all(message=str(e)), flush=True)
+                print(MarkusTester.error_all(message=str(e), expected=True), flush=True)
             except Exception:
                 print(MarkusTester.error_all(message=traceback.format_exc()), flush=True)
             finally:

--- a/testers/testers/markus_tester.py
+++ b/testers/testers/markus_tester.py
@@ -251,6 +251,7 @@ class MarkusTester(ABC):
         Err all tests of this tester with a single message.
         :param message: The error message.
         :param points_total: The total points the tests could earn, must be a float >= 0.
+        :param expected: Indicates whether this reports an expected or an unexpected tester error.
         :return The formatted erred tests.
         """
         status = MarkusTest.Status.ERROR if expected else MarkusTest.Status.ERROR_ALL

--- a/testers/testers/racket/markus_racket_tester.py
+++ b/testers/testers/racket/markus_racket_tester.py
@@ -46,7 +46,11 @@ class MarkusRacketTester(MarkusTester):
             if test_file:
                 suite_name = group.get('test_suite_name', 'all-tests')
                 cmd = [markus_rkt, '--test-suite', suite_name, test_file]
-                rkt = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, check=True)
+                rkt = subprocess.run(cmd,
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE,
+                                     universal_newlines=True,
+                                     check=True)
                 results[test_file] = rkt.stdout
         return results
         

--- a/testers/testers/racket/markus_racket_tester.py
+++ b/testers/testers/racket/markus_racket_tester.py
@@ -46,7 +46,7 @@ class MarkusRacketTester(MarkusTester):
             if test_file:
                 suite_name = group.get('test_suite_name', 'all-tests')
                 cmd = [markus_rkt, '--test-suite', suite_name, test_file]
-                rkt = subprocess.run(cmd, stdout=subprocess.PIPE, universal_newlines=True)
+                rkt = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, check=True)
                 results[test_file] = rkt.stdout
         return results
         
@@ -55,8 +55,7 @@ class MarkusRacketTester(MarkusTester):
         try:
             results = self.run_racket_test()
         except subprocess.CalledProcessError as e:
-            msg = e.stdout + e.stderr
-            raise MarkusTestError(msg) from e
+            raise MarkusTestError(e.stderr) from e
         with self.open_feedback() as feedback_open:
             for test_file, result in results.items():
                 if result.strip():


### PR DESCRIPTION
- only mark unexpected tests as having an `'error_all'` status
- this will mean that MarkUs will not stop parsing test results if an expected error is raised
- mark test file compilation/discovery errors as expected