### PR TITLE
Make subdirectories writeable in test workspace

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,11 @@
 # CHANGELOG
-
 All notable changes to this project will be documented here.
 
-_NOTE: This changelog starts from version 1.8.1 (changes prior to this version are not documented)_
+## [unreleased]
+- allow tests to write to existing subdirectories but not overwrite existing test script files (#237)
 
 ## [1.8.1]
+_NOTE: This changelog starts from version 1.8.1 (changes prior to this version are not documented)_
 ### Added
 - changelog
 - for all changes prior to this version see https://github.com/MarkUsProject/markus-autotesting/pulls?utf8=%E2%9C%93&q=is%3Apr+created%3A%3C2019-12-19+

--- a/server/autotest_server.py
+++ b/server/autotest_server.py
@@ -353,24 +353,24 @@ def setup_files(files_path, tests_path, markus_address, assignment_id):
     then make it the current working directory.
     The following permissions are also set:
         - tests_path directory:     rwxrwx--T
-        - test subdirectories:      rwxr-xr-x
-        - test files:               rw-r--r--
-        - student subdirectories:   rwxrwxrwx
-        - student files:            rw-rw-rw-
+        - test subdirectories:      rwxrwx--T
+        - test files:               rw-r-----
+        - student subdirectories:   rwxrwx---
+        - student files:            rw-rw----
     """
     os.chmod(tests_path, 0o1770)
     student_files = move_tree(files_path, tests_path)
     for fd, file_or_dir in student_files:
         if fd == 'd':
-            os.chmod(file_or_dir, 0o777)
+            os.chmod(file_or_dir, 0o770)
         else:
-            os.chmod(file_or_dir, 0o666)
+            os.chmod(file_or_dir, 0o660)
     script_files = copy_test_script_files(markus_address, assignment_id, tests_path)
     for fd, file_or_dir in script_files:
         if fd == 'd':
-            os.chmod(file_or_dir, 0o1777)
+            os.chmod(file_or_dir, 0o1770)
         else:
-            os.chmod(file_or_dir, 0o644)
+            os.chmod(file_or_dir, 0o640)
     return student_files, script_files
 
 def test_run_command(test_username=None):

--- a/server/autotest_server.py
+++ b/server/autotest_server.py
@@ -367,10 +367,10 @@ def setup_files(files_path, tests_path, markus_address, assignment_id):
             os.chmod(file_or_dir, 0o666)
     script_files = copy_test_script_files(markus_address, assignment_id, tests_path)
     for fd, file_or_dir in script_files:
-        permissions = 0o755 
-        if fd == 'f':
-            permissions -= 0o111
-        os.chmod(file_or_dir, permissions)
+        if fd == 'd':
+            os.chmod(file_or_dir, 0o1777)
+        else:
+            os.chmod(file_or_dir, 0o644)
     return student_files, script_files
 
 def test_run_command(test_username=None):


### PR DESCRIPTION
- allow tests to write to existing subdirectories but not overwrite existing test script files