### PR TITLE
Docker: connect to MarkUs containers

### DIFF
--- a/.dockerfiles/Dockerfile
+++ b/.dockerfiles/Dockerfile
@@ -5,7 +5,10 @@ FROM ubuntu:$UBUNTU_VERSION
 ARG LOGIN_USER
 
 RUN apt-get update && \
-    apt-get -y install sudo
+    apt-get -y install sudo && \
+    apt-get -y install openssh-server
+
+RUN mkdir /var/run/sshd && chmod 755 /var/run/sshd
 
 # Create a directory for the app code (keep the name generic)
 RUN mkdir -p /app
@@ -14,6 +17,12 @@ RUN useradd -ms /bin/bash $LOGIN_USER && \
     usermod -aG sudo $LOGIN_USER && \
     echo "$LOGIN_USER ALL=(ALL) NOPASSWD:ALL" | sudo tee "/etc/sudoers.d/$LOGIN_USER"
 
+RUN mkdir /ssh_pub_key && touch /ssh_pub_key/authorized_keys
+
 USER $LOGIN_USER
+RUN mkdir /home/$LOGIN_USER/.ssh && \
+    chown $LOGIN_USER. /home/$LOGIN_USER/.ssh && \
+    chmod 700 /home/$LOGIN_USER/.ssh && \
+    ln -s /ssh_pub_key/authorized_keys /home/$LOGIN_USER/.ssh/authorized_keys
 
 WORKDIR /app

--- a/.dockerfiles/entrypoint-dev.sh
+++ b/.dockerfiles/entrypoint-dev.sh
@@ -2,9 +2,17 @@
 
 set -e
 
-if [ ! -f /.installed ]; then
-  /app/bin/install.sh -p '3.8' --docker
-  sudo touch /.installed
+if [ ! -f /app/.installed ]; then
+  /app/bin/install.sh -p '3.8' --docker --all-testers
+
+  echo "export REDIS_URL=${REDIS_URL}
+        export PGHOST=${PGHOST}
+        export PGPORT=${PGPORT}
+        export MARKUS_AUTOTESTER_CONFIG=${MARKUS_AUTOTESTER_CONFIG}
+        " >> "${HOME}/.bash_profile"
+  touch /app/.installed
 fi
+
+sudo "$(command -v sshd)"
 
 exec "$@"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+**/.DS_Store
+.git/
+venv/
+.eggs/
+**/.pytest_cache
+**/*.egg-info
+.installed

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__
 .eggs
 venv
 
+# tmp files
+.installed
+
 # bin
 bin/kill_worker_procs
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented here.
     - configuration file defaults are now included in the source code so the autotester can be run with or without a
       user specific configuration file.
     - changed the default location for the workspace directory.
+- Updated development docker image to connect to the development MarkUs docker image (#238)
 
 ## [1.8.1]
 _NOTE: This changelog starts from version 1.8.1 (changes prior to this version are not documented)_

--- a/bin/start-stop.sh
+++ b/bin/start-stop.sh
@@ -10,14 +10,14 @@ RQ="${PROJECTROOT}/venv/bin/rq"
 SUPERVISORD="${PROJECTROOT}/venv/bin/supervisord"
 
 start_supervisor() {
-	local pid_file
-	pid_file="${LOGS_DIR}/supervisord.pid"
-	if [ -f "${pid_file}" ]; then
-	  local supervisor_pid
-	  supervisor_pid=$(cat "${pid_file}")
-		echo "Supervisor appears to be running already (PID: ${supervisor_pid})" >&2
-		exit 1
-	fi
+#	local pid_file
+#	pid_file="${LOGS_DIR}/supervisord.pid"
+#	if [ -f "${pid_file}" ]; then
+#	  local supervisor_pid
+#	  supervisor_pid=$(cat "${pid_file}")
+#		echo "Supervisor appears to be running already (PID: ${supervisor_pid})" >&2
+#		exit 1
+#	fi
 	(cd "${LOGS_DIR}" && ${SUPERVISORD} -c supervisord.conf)
 }
 

--- a/bin/start-stop.sh
+++ b/bin/start-stop.sh
@@ -10,14 +10,6 @@ RQ="${PROJECTROOT}/venv/bin/rq"
 SUPERVISORD="${PROJECTROOT}/venv/bin/supervisord"
 
 start_supervisor() {
-#	local pid_file
-#	pid_file="${LOGS_DIR}/supervisord.pid"
-#	if [ -f "${pid_file}" ]; then
-#	  local supervisor_pid
-#	  supervisor_pid=$(cat "${pid_file}")
-#		echo "Supervisor appears to be running already (PID: ${supervisor_pid})" >&2
-#		exit 1
-#	fi
 	(cd "${LOGS_DIR}" && ${SUPERVISORD} -c supervisord.conf)
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     user: docker
     volumes:
       - .:/app:cached
+      - ssh_pub_key:/ssh_pub_key:ro
     environment:
       - USER=docker
       - REDIS_URL=redis://redis_autotest:6379/
@@ -21,6 +22,9 @@ services:
       - PGPORT=5432
       - EDITOR=vi
       - MARKUS_AUTOTESTER_CONFIG=/app/.dockerfiles/docker-config.yml
+    networks:
+      - default
+      - markus_dev
     depends_on:
       - postgres_autotest
       - redis_autotest
@@ -28,6 +32,7 @@ services:
   autotest:
     <<: *app
     entrypoint: .dockerfiles/entrypoint-dev.sh
+    container_name: autotest
     command: '/bin/bash'
 
   postgres_autotest:
@@ -51,3 +56,10 @@ services:
 volumes:
   postgres_autotest:
   redis_autotest:
+  ssh_pub_key:
+     name: ssh_pub_key
+
+networks:
+  markus_dev:
+    external:
+      name: markus_dev

--- a/src/autotester/resources/postgresql/__init__.py
+++ b/src/autotester/resources/postgresql/__init__.py
@@ -10,6 +10,7 @@ POSTGRES_PREFIX = config["resources", "postgresql", "_prefix"]
 PGPASSFILE = os.path.join(
     config["workspace"], config["_workspace_contents", "_logs"], ".pgpass"
 )
+PGHOST = config["resources", "postgresql", "host"]
 
 
 def setup_database(test_username):
@@ -20,7 +21,7 @@ def setup_database(test_username):
         password = f.read().strip()
 
     with psycopg2.connect(
-        database=database, user=user, password=password, host="localhost"
+        database=database, user=user, password=password, host=PGHOST
     ) as conn:
         with conn.cursor() as cursor:
             cursor.execute("DROP OWNED BY CURRENT_USER;")

--- a/src/autotester/server/server.py
+++ b/src/autotester/server/server.py
@@ -375,8 +375,7 @@ def run_test(
             stop_tester_processes(test_username)
             clear_working_directory(tests_path, test_username)
     except Exception as e:
-        import traceback
-        error = traceback.format_exc() + str(e)
+        error = str(e)
     finally:
         results_data = finalize_results_data(
             results, error, hooks_error, time_to_service

--- a/src/autotester/server/server.py
+++ b/src/autotester/server/server.py
@@ -147,7 +147,7 @@ def kill_without_reaper(test_username):
     Kill all processes that test_username is able to kill
     """
     kill_cmd = f"sudo -u {test_username} -- bash -c 'kill -KILL -1'"
-    subprocess.run(kill_cmd, shell=True)
+    subprocess.run(kill_cmd)
 
 
 def create_test_script_command(env_dir, tester_type):
@@ -375,7 +375,8 @@ def run_test(
             stop_tester_processes(test_username)
             clear_working_directory(tests_path, test_username)
     except Exception as e:
-        error = str(e)
+        import traceback
+        error = traceback.format_exc() + str(e)
     finally:
         results_data = finalize_results_data(
             results, error, hooks_error, time_to_service

--- a/src/autotester/server/utils/user_management.py
+++ b/src/autotester/server/utils/user_management.py
@@ -33,4 +33,4 @@ def tester_user():
 def get_reaper_username(test_username):
     for users in (users for conf in config["workers"] for users in conf["users"]):
         if users["name"] == test_username:
-            return users["reaper"]
+            return users.get("reaper")

--- a/src/autotester/testers/custom/bin/install.sh
+++ b/src/autotester/testers/custom/bin/install.sh
@@ -3,8 +3,8 @@
 set -e
 
 # script starts here
-if [[ $# -ne 0 ]]; then
-    echo "Usage: $0"
+if [[ $# -gt 1 ]]; then
+    echo "Usage: $0 [--non-interactive]"
     exit 1
 fi
 

--- a/src/autotester/testers/haskell/bin/install.sh
+++ b/src/autotester/testers/haskell/bin/install.sh
@@ -4,7 +4,15 @@ set -e
 
 install_packages() {
     echo "[HASKELL-INSTALL] Installing system packages"
-    sudo apt-get install ghc cabal-install python3
+    local debian_frontend
+    local apt_opts
+    local apt_yes
+    if [ -n "${NON_INTERACTIVE}" ]; then
+      debian_frontend=noninteractive
+      apt_opts=(-o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold')
+      apt_yes='-y'
+    fi
+    sudo DEBIAN_FRONTEND=${debian_frontend} apt-get ${apt_yes} "${apt_opts[@]}" install ghc cabal-install
 }
 
 install_haskell_packages() {
@@ -18,8 +26,8 @@ install_haskell_packages() {
 }
 
 # script starts here
-if [[ $# -ne 0 ]]; then
-    echo "Usage: $0"
+if [[ $# -gt 1 ]]; then
+    echo "Usage: $0 [--non-interactive]"
     exit 1
 fi
 
@@ -27,6 +35,7 @@ fi
 THISSCRIPT=$(readlink -f "${BASH_SOURCE[0]}")
 THISDIR=$(dirname "${THISSCRIPT}")
 SPECSDIR=$(readlink -f "${THISDIR}/../specs")
+NON_INTERACTIVE=$1
 
 # main
 install_packages

--- a/src/autotester/testers/java/bin/install.sh
+++ b/src/autotester/testers/java/bin/install.sh
@@ -4,7 +4,15 @@ set -e
 
 install_packages() {
     echo "[JAVA-INSTALL] Installing system packages"
-    sudo apt-get install python3 openjdk-8-jdk jq
+    local debian_frontend
+    local apt_opts
+    local apt_yes
+    if [ -n "${NON_INTERACTIVE}" ]; then
+      debian_frontend=noninteractive
+      apt_opts=(-o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold')
+      apt_yes='-y'
+    fi
+    sudo DEBIAN_FRONTEND=${debian_frontend} apt-get ${apt_yes} "${apt_opts[@]}" install openjdk-8-jdk
 }
 
 compile_tester() {
@@ -20,8 +28,8 @@ update_specs() {
 }
 
 # script starts here
-if [[ $# -ne 0 ]]; then
-    echo "Usage: $0"
+if [[ $# -gt 1 ]]; then
+    echo "Usage: $0 [--non-interactive]"
     exit 1
 fi
 
@@ -30,6 +38,7 @@ THISSCRIPT=$(readlink -f "${BASH_SOURCE[0]}")
 THISDIR=$(dirname "${THISSCRIPT}")
 SPECSDIR=$(readlink -f "${THISDIR}/../specs")
 JAVADIR=$(readlink -f "${THISDIR}/../lib")
+NON_INTERACTIVE=$1
 
 # main
 install_packages

--- a/src/autotester/testers/py/bin/install.sh
+++ b/src/autotester/testers/py/bin/install.sh
@@ -2,14 +2,9 @@
 
 set -e
 
-install_packages() {
-    echo "[PYTHON-INSTALL] Installing system packages"
-    sudo apt-get install python3
-}
-
 # script starts here
-if [[ $# -ne 0 ]]; then
-    echo "Usage: $0"
+if [[ $# -gt 1 ]]; then
+    echo "Usage: $0 [--non-interactive]"
     exit 1
 fi
 
@@ -19,5 +14,4 @@ THISDIR=$(dirname "${THISSCRIPT}")
 SPECSDIR=$(readlink -f "${THISDIR}/../specs")
 
 # main
-install_packages
 touch "${SPECSDIR}/.installed"

--- a/src/autotester/testers/pyta/bin/install.sh
+++ b/src/autotester/testers/pyta/bin/install.sh
@@ -2,14 +2,9 @@
 
 set -e
 
-install_packages() {
-    echo "[PYTA-INSTALL] Installing system packages"
-    sudo apt-get install python3
-}
-
 # script starts here
-if [[ $# -ne 0 ]]; then
-    echo "Usage: $0"
+if [[ $# -gt 1 ]]; then
+    echo "Usage: $0 [--non-interactive]"
     exit 1
 fi
 
@@ -19,5 +14,4 @@ THISDIR=$(dirname "${THISSCRIPT}")
 SPECSDIR=$(readlink -f "${THISDIR}/../specs")
 
 # main
-install_packages
 touch "${SPECSDIR}/.installed"

--- a/src/autotester/testers/racket/bin/install.sh
+++ b/src/autotester/testers/racket/bin/install.sh
@@ -4,12 +4,20 @@ set -e
 
 install_packages() {
     echo "[RACKET-INSTALL] Installing system packages"
-    sudo apt-get install racket python3
+    local debian_frontend
+    local apt_opts
+    local apt_yes
+    if [ -n "${NON_INTERACTIVE}" ]; then
+      debian_frontend=noninteractive
+      apt_opts=(-o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold')
+      apt_yes='-y'
+    fi
+    sudo DEBIAN_FRONTEND=${debian_frontend} apt-get ${apt_yes} "${apt_opts[@]}" install racket
 }
 
 # script starts here
-if [[ $# -ne 0 ]]; then
-    echo "Usage: $0"
+if [[ $# -gt 1 ]]; then
+    echo "Usage: $0 [--non-interactive]"
     exit 1
 fi
 
@@ -17,6 +25,7 @@ fi
 THISSCRIPT=$(readlink -f "${BASH_SOURCE[0]}")
 THISDIR=$(dirname "${THISSCRIPT}")
 SPECSDIR=$(readlink -f "${THISDIR}/../specs")
+NON_INTERACTIVE=$1
 
 # main
 install_packages


### PR DESCRIPTION
- uses the `markus_dev` bridge network which is shared with the MarkUs `rails` service
- set up ssh server on the `autotest` service (and install rsync for passing files from MarkUs)
- introduce `.dockerignore` file to reduce build footprint
- set environment variables in `.bash_profile` and source them before running the `autotest_enqueuer` command (required because MarkUs connects with the `Net::SSH` gem which does not source any of `.profile`, `.bash_profile`, `.bashrc`)
- automatically pass MarkUs' rsa public key using a volume (`ssh_pub_key`)
- use `PGHOST` environment variable to set postgres hostname
- allow for null reaper user
- make sure environment variables are passed to process that is generating `supervisord.conf` file
- allow installation of testers non-interactively

TODO:

- [x] update changelog

Requires: https://github.com/MarkUsProject/Markus/pull/4389