### PR TITLE
Docker: Added new env variable in postgres image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
     - ./log:/root/log:cached
     environment:
     - PSQL_HISTFILE=/root/log/.psql_history
+    - POSTGRES_HOST_AUTH_METHOD=trust
     ports:
     - '45432:5432'
 


### PR DESCRIPTION
This is same like #4385 in MarkUsProject/Markus
when we try to start up postgres it raises the following error
**Error** : Database is uninitialized and superuser password is not specified.
You must specify POSTGRES_PASSWORD for the superuser. Use
"-e POSTGRES_PASSWORD=password" to set it in "docker run".
You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all connections
without a password.
**Change:**
Added the POSTGRES_HOST_AUTH_METHOD=trust