### PR TITLE
Fix: Modified path_management.py

### DIFF
--- a/src/autotester/server/utils/path_management.py
+++ b/src/autotester/server/utils/path_management.py
@@ -36,6 +36,6 @@ def add_path(path, prepend=True):
     finally:
         try:
             i = (sys.path if prepend else sys.path[::-1]).index(path)
-            sys.path.pop(i)
+            sys.path.pop(i if prepend else -(i+1))
         except ValueError:
             pass

--- a/src/autotester/server/utils/path_management.py
+++ b/src/autotester/server/utils/path_management.py
@@ -40,6 +40,6 @@ def add_path(path, prepend=True):
                 sys.path.pop(i)
             else:
                 i = (sys.path[::-1]).index(path)
-                sys.path.pop(-(i+1))
+                sys.path.pop(-(i + 1))
         except ValueError:
             pass

--- a/src/autotester/server/utils/path_management.py
+++ b/src/autotester/server/utils/path_management.py
@@ -35,7 +35,11 @@ def add_path(path, prepend=True):
         yield
     finally:
         try:
-            i = (sys.path if prepend else sys.path[::-1]).index(path)
-            sys.path.pop(i if prepend else -(i + 1))
+            if prepend:
+                i = sys.path.index(path)
+                sys.path.pop(i)
+            else:
+                i = (sys.path[::-1]).index(path)
+                sys.path.pop(-(i+1))
         except ValueError:
             pass

--- a/src/autotester/server/utils/path_management.py
+++ b/src/autotester/server/utils/path_management.py
@@ -36,6 +36,6 @@ def add_path(path, prepend=True):
     finally:
         try:
             i = (sys.path if prepend else sys.path[::-1]).index(path)
-            sys.path.pop(i if prepend else -(i+1))
+            sys.path.pop(i if prepend else -(i + 1))
         except ValueError:
             pass


### PR DESCRIPTION
Issue:
In path_management.py when we try to append path into sys.path it temporarily add path and finally it has to delete it but it is not deleting properly. We are not actually using this anywhere else in the code so it wasn't an issue before.
Fix:
Modified the method add_path, now it will work for both append and prepend.