### PR TITLE
Chown test files to be group owned by test user

### DIFF
--- a/src/autotester/server/server.py
+++ b/src/autotester/server/server.py
@@ -366,7 +366,9 @@ def run_test(
         testers = {settings["tester_type"] for settings in test_specs["testers"]}
         hooks = Hooks(hooks_script_path, testers, cwd=tests_path, kwargs=hooks_kwargs)
         try:
-            setup_files(files_path, tests_path, test_username, markus_address, assignment_id)
+            setup_files(
+                files_path, tests_path, test_username, markus_address, assignment_id
+            )
             cmd = run_test_command(test_username=test_username)
             results, hooks_error = run_test_specs(
                 cmd, test_specs, test_categories, tests_path, test_username, hooks

--- a/src/autotester/server/server.py
+++ b/src/autotester/server/server.py
@@ -366,7 +366,7 @@ def run_test(
         testers = {settings["tester_type"] for settings in test_specs["testers"]}
         hooks = Hooks(hooks_script_path, testers, cwd=tests_path, kwargs=hooks_kwargs)
         try:
-            setup_files(files_path, tests_path, markus_address, assignment_id)
+            setup_files(files_path, tests_path, test_username, markus_address, assignment_id)
             cmd = run_test_command(test_username=test_username)
             results, hooks_error = run_test_specs(
                 cmd, test_specs, test_categories, tests_path, test_username, hooks

--- a/src/autotester/server/utils/file_management.py
+++ b/src/autotester/server/utils/file_management.py
@@ -122,7 +122,7 @@ def copy_test_script_files(markus_address, assignment_id, tests_path):
     return []
 
 
-def setup_files(files_path, tests_path, markus_address, assignment_id):
+def setup_files(files_path, tests_path, test_username, markus_address, assignment_id):
     """
     Copy test script files and student files to the working directory tests_path,
     then make it the current working directory.
@@ -140,10 +140,12 @@ def setup_files(files_path, tests_path, markus_address, assignment_id):
             os.chmod(file_or_dir, 0o770)
         else:
             os.chmod(file_or_dir, 0o660)
+        shutil.chown(file_or_dir, group=test_username)
     script_files = copy_test_script_files(markus_address, assignment_id, tests_path)
     for fd, file_or_dir in script_files:
         if fd == "d":
             os.chmod(file_or_dir, 0o1770)
         else:
             os.chmod(file_or_dir, 0o640)
+        shutil.chown(file_or_dir, group=test_username)
     return student_files, script_files


### PR DESCRIPTION
- this is required to allow the server user to have enough permissions to copy files and clean up the work directory, while simultaneously only giving one specific tester user permission to read/write/execute a file/directory. 