### PR TITLE
Update layerfile to use new syntax

### DIFF
--- a/Layerfile
+++ b/Layerfile
@@ -4,11 +4,7 @@ RUN apt-get update && \
     apt-get -y install python3 python3-pip python3-venv && \
     rm -rf /var/lib/apt/lists/*
 
-CHECKPOINT
-
 RUN python3 -m venv /tmp/venv
-
-CHECKPOINT
 
 WORKDIR /app
 COPY . .

--- a/Layerfile
+++ b/Layerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM vm/ubuntu:18.04
 
 RUN apt-get update && \
     apt-get -y install python3 python3-pip python3-venv && \


### PR DESCRIPTION
- the base image in the layer file must now be specified by prefixing the image name with `vm/`
- checkpoints happen automatically and are no longer required