### PR TITLE
Treat validation error message like an expected error

### DIFF
--- a/src/autotester/cli.py
+++ b/src/autotester/cli.py
@@ -161,7 +161,8 @@ def update_specs(test_specs, schema=None, **kw):
             schema, test_specs, best_only=True
         )
         if error:
-            raise error
+            sys.stderr.write(f'Form Validation Error: {str(error)}')
+            sys.exit(1)
     update_test_specs(test_specs=test_specs, **kw)
 
 

--- a/src/autotester/cli.py
+++ b/src/autotester/cli.py
@@ -161,7 +161,7 @@ def update_specs(test_specs, schema=None, **kw):
             schema, test_specs, best_only=True
         )
         if error:
-            sys.stderr.write(f'Form Validation Error: {str(error)}')
+            sys.stderr.write(f"Form Validation Error: {str(error)}")
             sys.exit(1)
     update_test_specs(test_specs=test_specs, **kw)
 

--- a/src/autotester/tests/cli_test.py
+++ b/src/autotester/tests/cli_test.py
@@ -208,11 +208,8 @@ class TestUpdateSpecs:
             return_value=DummyTestError("error"),
         ):
             with patch("autotester.cli.update_test_specs"):
-                try:
+                with pytest.raises(SystemExit):
                     cli.update_specs("", **self.get_kwargs(schema={}))
-                except DummyTestError:
-                    return
-        pytest.fail("should have failed because the form is invalid")
 
     def test_succeeds_when_schema_is_valid(self):
         with patch(


### PR DESCRIPTION
- Don't show full traceback for a validation error (it's already confusing enough as it is for the user)
- As a side note, [rjsf](https://github.com/rjsf-team/react-jsonschema-form) still doesn't fill in our defaults properly by itself (it looks like because the `oneOf` types are [mostly but not fully supported](https://react-jsonschema-form.readthedocs.io/en/latest/#q-does-rjsf-support-oneof-anyof-multiple-types-in-an-array-etc)) so we still need to fill in defaults and validate in the autotester itself.