### PR TITLE
Run supervisor process in foreground on docker

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -273,15 +273,21 @@ start_workers() {
   local supervisorconf
   local generate_script
   local rq
+  local worker_cmd
 
   supervisorconf="${WORKSPACE_SUBDIRS[LOGS]}/supervisord.conf"
   generate_script="${BINDIR}/generate_supervisord_conf.py"
   rq="${SERVER_VENV}/bin/rq"
+  worker_cmd="${PYTHON} ${generate_script} ${rq} ${supervisorconf}"
 
 
   echo "[AUTOTEST-INSTALL] Generating supervisor config at '${supervisorconf}' and starting rq workers"
-  sudo -Eu "${SERVER_USER}" -- bash -c "${PYTHON} ${generate_script} ${rq} ${supervisorconf} &&
-                                      ${BINDIR}/start-stop.sh start"
+  if [ -z "${DOCKER}" ]; then
+    echo "[AUTOTEST-INSTALL] Starting rq workers"
+    worker_cmd="${worker_cmd} && ${BINDIR}/start-stop.sh start"
+  fi
+
+  sudo -Eu "${SERVER_USER}" -- bash -c "${worker_cmd}"
 }
 
 install_testers() {

--- a/bin/start-stop.sh
+++ b/bin/start-stop.sh
@@ -10,7 +10,7 @@ RQ="${PROJECTROOT}/venv/bin/rq"
 SUPERVISORD="${PROJECTROOT}/venv/bin/supervisord"
 
 start_supervisor() {
-	(cd "${LOGS_DIR}" && ${SUPERVISORD} -c supervisord.conf)
+	(cd "${LOGS_DIR}" && ${SUPERVISORD} -c supervisord.conf "$@")
 }
 
 stop_supervisor() {
@@ -48,14 +48,14 @@ fi
 
 case $1 in 
 	start)
-		start_supervisor
+		start_supervisor "${@:2}"
 		;;
 	stop)
 		stop_supervisor
 		;;
 	restart)
 		stop_supervisor
-		start_supervisor
+		start_supervisor "${@:2}"
 		;;
 	stat)
 		"${RQ}" info --url "${REDIS_URL}" "${@:2}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     <<: *app
     entrypoint: .dockerfiles/entrypoint-dev.sh
     container_name: autotest
-    command: '/bin/bash'
+    command: './bin/start-stop.sh start --nodaemon --logfile -'
 
   postgres_autotest:
     image: postgres:10
@@ -53,6 +53,15 @@ services:
     - redis_autotest:/data
     ports:
     - 6379
+
+  rq_dashboard:
+    image: eoranged/rq-dashboard
+    environment:
+      - RQ_DASHBOARD_REDIS_URL=redis://redis_autotest:6379/
+    ports:
+      - '9181:9181'
+    depends_on:
+      - redis_autotest
 
 volumes:
   postgres_autotest:

--- a/src/autotester/server/server.py
+++ b/src/autotester/server/server.py
@@ -303,17 +303,15 @@ def clear_working_directory(tests_path: str, test_username: str) -> None:
     Run commands that clear the tests_path working directory
     """
     if test_username != current_user():
-        chmod_cmd = "sudo -u {} -- bash -c 'chmod -Rf ugo+rwX {}'".format(
-            test_username, tests_path
-        )
+        chmod_cmd = f"sudo -u {test_username} -- bash -c 'chmod -Rf ugo+rwX {tests_path}'"
     else:
-        chmod_cmd = "chmod -Rf ugo+rwX {}".format(tests_path)
+        chmod_cmd = f"chmod -Rf ugo+rwX {tests_path}"
 
     subprocess.run(chmod_cmd, shell=True)
 
     # be careful not to remove the tests_path dir itself since we have to
     # set the group ownership with sudo (and that is only done in ../install.sh)
-    clean_cmd = "rm -rf {0}/.[!.]* {0}/*".format(tests_path)
+    clean_cmd = f"rm -rf {tests_path}/.[!.]* {tests_path}/*"
     subprocess.run(clean_cmd, shell=True)
 
 


### PR DESCRIPTION
- also add another service for rq_dashboard. you can now monitor rq jobs in your browser from `localhost:9181`