### PR TITLE
Docker: keep install flag inside the container

### DIFF
--- a/.dockerfiles/entrypoint-dev.sh
+++ b/.dockerfiles/entrypoint-dev.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ ! -f /app/.installed ]; then
+if [ ! -f "${HOME}/.installed" ]; then
   /app/bin/install.sh -p '3.8' --docker --all-testers
 
   echo "export REDIS_URL=${REDIS_URL}
@@ -10,7 +10,7 @@ if [ ! -f /app/.installed ]; then
         export PGPORT=${PGPORT}
         export MARKUS_AUTOTESTER_CONFIG=${MARKUS_AUTOTESTER_CONFIG}
         " >> "${HOME}/.bash_profile"
-  touch /app/.installed
+  touch "${HOME}/.installed"
 fi
 
 sudo "$(command -v sshd)"


### PR DESCRIPTION
This change means that the `.installed` file that is created to signal that the tester has already been installed in the container only exists in the container in question. This means that a new container will always run the install script.