### PR TITLE
Replace tasty-stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__
 *.egg-info
 .eggs
 venv
+build
 
 # tmp files
 .installed

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 - Updated development docker image to connect to the development MarkUs docker image (#238)
+- Removed Tasty-Stats as a dependency for the haskell tester and added our own ingredient instead to collect stats (#259)
 
 ## [1.9.0]
 - allow tests to write to existing subdirectories but not overwrite existing test script files (#237).

--- a/src/autotester/MANIFEST.in
+++ b/src/autotester/MANIFEST.in
@@ -1,3 +1,4 @@
 include testers/racket/lib/markus.rkt
+include testers/haskell/lib/Stats.hs
 graft testers/java/lib
 include testers/*/specs/install_settings.json

--- a/src/autotester/testers/haskell/bin/install.sh
+++ b/src/autotester/testers/haskell/bin/install.sh
@@ -20,7 +20,6 @@ install_haskell_packages() {
     # The order that these packages are installed matters. Could cause a dependency conflict 
     # Crucially it looks like tasty-stats needs to be installed before tasty-quickcheck 
     # TODO: install these without cabal so they can be properly isolated/uninstalled
-    sudo cabal install tasty-stats --global
     sudo cabal install tasty-discover --global
     sudo cabal install tasty-quickcheck --global
 }

--- a/src/autotester/testers/haskell/lib/Stats.hs
+++ b/src/autotester/testers/haskell/lib/Stats.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ViewPatterns #-}
+module Stats (statsReporter, consoleStatsReporter) where
+
+-- a paired down version of the Tasty Stats ingredient that crucially does not depend on git:
+-- https://hackage.haskell.org/package/tasty-stats
+
+import Control.Concurrent.STM (atomically, readTVar, TVar, STM, retry)
+import Control.Monad ((>=>))
+import Data.Char (isSpace, isPrint)
+import Data.Foldable (fold)
+import Data.IntMap (IntMap)
+import Data.List (dropWhileEnd, intersperse)
+import Data.Monoid (Endo(..))
+import Data.Proxy (Proxy(..))
+import Data.Tagged (Tagged(..))
+import System.Directory (doesFileExist)
+import Test.Tasty
+import Test.Tasty.Ingredients
+import Test.Tasty.Options
+import Test.Tasty.Runners
+import qualified Data.IntMap as IntMap
+
+newtype StatsFile = StatsFile FilePath
+
+instance IsOption (Maybe StatsFile) where
+  defaultValue = Nothing
+  parseValue = Just . Just . StatsFile
+  optionName = Tagged "stats"
+  optionHelp = Tagged "CSV file to store the collected statistics"
+
+-- | Reporter with support to collect statistics in a file.
+statsReporter :: Ingredient
+statsReporter = TestReporter optDesc runner
+  where optDesc = [ Option (Proxy :: Proxy (Maybe StatsFile)) ]
+        runner opts tree = do
+          StatsFile file <- lookupOption opts
+          pure $ collectStats (getNumThreads $ lookupOption opts) file $ IntMap.fromList $ zip [0..] $ testsNames opts tree
+
+-- | Console reporter with support to collect statistics in a file.
+consoleStatsReporter :: Ingredient
+consoleStatsReporter = composeReporters consoleTestReporter statsReporter
+
+zipMap :: IntMap a -> IntMap b -> IntMap (a, b)
+zipMap a b = IntMap.mapMaybeWithKey (\k v -> (v,) <$> IntMap.lookup k b) a
+
+waitFinished :: TVar Status -> STM Result
+waitFinished = readTVar >=> \case
+  Done x -> pure x
+  _      -> retry
+
+collectStats :: Int -> FilePath -> IntMap TestName -> StatusMap -> IO (Time -> IO Bool)
+collectStats nthreads file names status = do
+  results <- atomically (traverse waitFinished status)
+  rows    <- resultRow nthreads $ IntMap.toList $ zipMap names results
+  exists  <- doesFileExist file
+  if exists
+    then appendFile file $ formatCSV rows ""
+    else writeFile  file $ formatCSV (header : rows) ""
+  pure $ const $ pure $ and $ fmap resultSuccessful results
+
+
+foldEndo :: (Functor f, Foldable f) => f (a -> a) -> (a -> a)
+foldEndo = appEndo . fold . fmap Endo
+
+formatCSV :: [[String]] -> ShowS
+formatCSV = foldEndo . map ((. ('\n':)) . foldEndo . intersperse (',':) . map field)
+  where field s | all isValid s = (s++)
+                | otherwise        = ('"':) . escape s . ('"':)
+        escape ('"':s) = ("\"\""++) . escape s
+        escape (c:s)   = (c:) . escape s
+        escape []      = id
+        isValid ' '    = True
+        isValid ','    = False
+        isValid c      = isPrint c && not (isSpace c)
+
+header :: [String]
+header = ["idx", "name", "time", "result", "nthreads", "description"]
+
+resultRow :: Int -> [(Int, (TestName, Result))] -> IO [[String]]
+resultRow nthreads' results = do
+  let nthreads = show nthreads'
+  pure $ flip map results $
+    \(show -> idx, (name, Result { resultDescription=dropWhileEnd isSpace -> description
+                                 , resultShortDescription=result
+                                 , resultTime=show -> time })) ->
+    [idx, name, time, result, nthreads, description]

--- a/src/autotester/testers/haskell/markus_haskell_tester.py
+++ b/src/autotester/testers/haskell/markus_haskell_tester.py
@@ -49,8 +49,6 @@ class MarkusHaskellTest(MarkusTest):
 
 
 class MarkusHaskellTester(MarkusTester):
-    # column indexes of relevant data from tasty-stats csv
-    # reference: http://hackage.haskell.org/package/tasty-stats
     TASTYSTATS = {"name": 1, "time": 2, "result": 3, "description": -1}
 
     def __init__(
@@ -70,7 +68,7 @@ class MarkusHaskellTester(MarkusTester):
         Return a list of additional arguments to the tasty-discover executable
         """
         module_flag = f"--modules={os.path.basename(test_file)}"
-        stats_flag = "--ingredient=Test.Tasty.Stats.consoleStatsReporter"
+        stats_flag = "--ingredient=Stats.consoleStatsReporter"
         flags = [
             module_flag,
             stats_flag,
@@ -105,6 +103,7 @@ class MarkusHaskellTester(MarkusTester):
         """
         results = {}
         this_dir = os.getcwd()
+        haskell_lib = os.path.join(os.path.dirname(os.path.realpath(__file__)), "lib")
         for test_file in self.specs["test_data", "script_files"]:
             with tempfile.NamedTemporaryFile(dir=this_dir) as f:
                 cmd = ["tasty-discover", ".", "_", f.name] + self._test_run_flags(
@@ -114,7 +113,7 @@ class MarkusHaskellTester(MarkusTester):
                     cmd, stdout=subprocess.DEVNULL, universal_newlines=True, check=True
                 )
                 with tempfile.NamedTemporaryFile(mode="w+", dir=this_dir) as sf:
-                    cmd = ["runghc", f.name, f"--stats={sf.name}"]
+                    cmd = ["runghc", "--", f"-i={haskell_lib}", f.name, f"--stats={sf.name}"]
                     subprocess.run(
                         cmd,
                         stdout=subprocess.DEVNULL,


### PR DESCRIPTION
The tasty-stats ingredient requires git to be installed to get data from tests that is unnecessary for our purposes. I would rather not require git for the entire project simply because the tasty-stats ingredient requires it. So instead I added our own Stats ingredient which is essentially just a paired down version of the tasty-stats ingredient.

TODO:

- [x] refactor and pair down Stats.hs further
- [x] update changelog