### PR TITLE
haskell: report test results even if full test run fails

### DIFF
--- a/src/autotester/testers/haskell/haskell_tester.py
+++ b/src/autotester/testers/haskell/haskell_tester.py
@@ -103,7 +103,7 @@ class HaskellTester(Tester):
                 with tempfile.NamedTemporaryFile(mode="w+", dir=this_dir) as sf:
                     cmd = ["runghc", "--", f"-i={haskell_lib}", f.name, f"--stats={sf.name}"]
                     subprocess.run(
-                        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, universal_newlines=True, check=True,
+                        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, universal_newlines=True
                     )
                     results[test_file] = self._parse_test_results(csv.reader(sf))
         return results


### PR DESCRIPTION
If a haskell test run returns a non-zero exit code then the partial test results were not being collected and reported properly.
This PR ensures that partial test results will still be reported regardless of the test process' exit status.