### PR TITLE
Correct version of isort for python < 3.8

### DIFF
--- a/src/autotester/testers/pyta/bin/requirements.txt
+++ b/src/autotester/testers/pyta/bin/requirements.txt
@@ -1,2 +1,3 @@
 python-ta==1.4.2;python_version<"3.8"
 python-ta>=1.5.0;python_version>="3.8"
+isort<5;python_version<"3.8"


### PR DESCRIPTION
Problem:

- pyta depends on pylint which depends on isort
- isort recently put out version 5 which has breaking changes
- pylint does not support version 5 of isort so the it installs the following version `isort>=4.2.5,<5`
- pyta version 1.4.2 installs `pylint>=2.1,<2.2`
- pylint 2.1 (and 2.2 as well actually) have the following import line for `isort>=4.2.5` which means that the latest version of isort is installed (5.1.1)
- this breaks pyta version 1.4.2 and so breaks the pytest autotester when run with python3.6 or 3.7

Solution:

- force isort to not use version 5 when the tester uses python 3.6 or 3.7