### PR TITLE
Pass PGHOST and PGPORT info to tests

### DIFF
--- a/src/autotester/resources/postgresql/__init__.py
+++ b/src/autotester/resources/postgresql/__init__.py
@@ -39,5 +39,6 @@ def setup_database(test_username: str) -> Dict[str, str]:
         "PGDATABASE": database,
         "PGPASSWORD": password,
         "PGUSER": user,
+        "PGHOST": PGHOST,
         "AUTOTESTENV": "true",
     }

--- a/src/autotester/resources/postgresql/__init__.py
+++ b/src/autotester/resources/postgresql/__init__.py
@@ -10,6 +10,7 @@ from autotester.config import config
 POSTGRES_PREFIX = config["resources", "postgresql", "_prefix"]
 PGPASSFILE = os.path.join(config["workspace"], config["_workspace_contents", "_logs"], ".pgpass")
 PGHOST = config["resources", "postgresql", "host"]
+PGPORT = config["resources", "postgresql", "port"]
 
 
 def setup_database(test_username: str) -> Dict[str, str]:
@@ -27,7 +28,7 @@ def setup_database(test_username: str) -> Dict[str, str]:
     with open(PGPASSFILE) as f:
         password = f.read().strip()
 
-    with psycopg2.connect(database=database, user=user, password=password, host=PGHOST) as conn:
+    with psycopg2.connect(database=database, user=user, password=password, host=PGHOST, port=PGPORT) as conn:
         with conn.cursor() as cursor:
             cursor.execute("DROP OWNED BY CURRENT_USER;")
             if test_username != user:
@@ -40,5 +41,6 @@ def setup_database(test_username: str) -> Dict[str, str]:
         "PGPASSWORD": password,
         "PGUSER": user,
         "PGHOST": PGHOST,
+        "PGPORT": PGPORT,
         "AUTOTESTENV": "true",
     }

--- a/src/autotester/testers/py/lib/sql_helper.py
+++ b/src/autotester/testers/py/lib/sql_helper.py
@@ -40,7 +40,7 @@ def connection(*args, **kwargs):
             "database": os.environ.get("PGDATABASE"),
             "password": os.environ.get("PGPASSWORD"),
             "user": os.environ.get("PGUSER"),
-            "host": "localhost",
+            "host": os.environ.get("PGHOST"),
         }
     return _unmockable_psycopg2_connect(*args, **kwargs)
 
@@ -99,7 +99,8 @@ def execute_psql_file(
     *args: str,
     database: Optional[str] = None,
     password: Optional[str] = None,
-    user: Optional[str] = None
+    user: Optional[str] = None,
+    host: Optional[str] = None
 ) -> subprocess.CompletedProcess:
     """
     Return a CompletedProcess object returned after calling:
@@ -140,6 +141,7 @@ def execute_psql_file(
             "PGUSER": user or os.environ.get("PGUSER"),
             "PGPASSWORD": password or os.environ.get("PGPASSWORD"),
             "PGDATABASE": database or os.environ.get("PGDATABASE"),
+            "PGHOST": host or os.environ.get("PGHOST")
         }
         env = {**os.environ, **db_vars}
     return subprocess.run(["psql", "-f", filename] + list(args), env=env, capture_output=True)

--- a/src/autotester/testers/py/lib/sql_helper.py
+++ b/src/autotester/testers/py/lib/sql_helper.py
@@ -41,6 +41,7 @@ def connection(*args, **kwargs):
             "password": os.environ.get("PGPASSWORD"),
             "user": os.environ.get("PGUSER"),
             "host": os.environ.get("PGHOST"),
+            "port": os.environ.get("PGPORT")
         }
     return _unmockable_psycopg2_connect(*args, **kwargs)
 
@@ -100,7 +101,8 @@ def execute_psql_file(
     database: Optional[str] = None,
     password: Optional[str] = None,
     user: Optional[str] = None,
-    host: Optional[str] = None
+    host: Optional[str] = None,
+    port: Optional[str] = None,
 ) -> subprocess.CompletedProcess:
     """
     Return a CompletedProcess object returned after calling:
@@ -141,7 +143,8 @@ def execute_psql_file(
             "PGUSER": user or os.environ.get("PGUSER"),
             "PGPASSWORD": password or os.environ.get("PGPASSWORD"),
             "PGDATABASE": database or os.environ.get("PGDATABASE"),
-            "PGHOST": host or os.environ.get("PGHOST")
+            "PGHOST": host or os.environ.get("PGHOST"),
+            "PGPORT": port or os.environ.get("PGPORT")
         }
         env = {**os.environ, **db_vars}
     return subprocess.run(["psql", "-f", filename] + list(args), env=env, capture_output=True)


### PR DESCRIPTION
Depending on how the postgres authorization is set up. You may need to explicitly pass the host and port parameter when running `psql` commands within a test. 
Previously, we defaulted to using "localhost" and 5432 but we can't always assume that the postgres server is running at localhost and with the default port.