### PR TITLE
Env variables (including the port number) need to be a string

### DIFF
--- a/src/autotester/resources/postgresql/__init__.py
+++ b/src/autotester/resources/postgresql/__init__.py
@@ -41,6 +41,6 @@ def setup_database(test_username: str) -> Dict[str, str]:
         "PGPASSWORD": password,
         "PGUSER": user,
         "PGHOST": PGHOST,
-        "PGPORT": PGPORT,
+        "PGPORT": str(PGPORT),
         "AUTOTESTENV": "true",
     }


### PR DESCRIPTION
- subprocess has a hard time setting the environment variables if one of the values of the dictionary passed to `Popen(...env=...)` is not a string
- this PR changes the port number to a string so that subprocess won't complain