### PR TITLE
Bump pyscopg2-binary version 2.8.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "rq==1.1.0",
         "supervisor==4.1.0",
         "PyYAML==5.1.2",
-        "psycopg2-binary==2.8.4",
+        "psycopg2-binary==2.8.6",
         "markusapi==0.2.0",
         "jsonschema==3.0.2",
     ],

--- a/src/autotester/testers/py/bin/requirements.txt
+++ b/src/autotester/testers/py/bin/requirements.txt
@@ -1,2 +1,2 @@
 pytest==5.3.1
-psycopg2-binary==2.8.4
+psycopg2-binary==2.8.6


### PR DESCRIPTION
previous version 2.8.4 is not compatible with python3.9