### PR TITLE
Always write supervisor log file to the same directory

### DIFF
--- a/server/start_stop.py
+++ b/server/start_stop.py
@@ -55,7 +55,7 @@ def create_enqueuer_wrapper():
 
 def start(extra_args):
     create_enqueuer_wrapper()
-    subprocess.run([_SUPERVISORD, "-c", _CONF_FILE, *extra_args], check=True)
+    subprocess.run([_SUPERVISORD, "-c", _CONF_FILE, *extra_args], check=True, cwd=_THIS_DIR)
 
 
 def stop():


### PR DESCRIPTION
The supervisor log file gets written to the current directory. If start_stop.sh is run from somewhere random, the log file can be hard to find later. This makes sure that the log file gets written somewhere consistent.