### PR TITLE
Try to re-install settings if they don't exist when tests are run

### DIFF
--- a/server/.dockerfiles/Dockerfile
+++ b/server/.dockerfiles/Dockerfile
@@ -7,19 +7,20 @@ ARG LOGIN_USER
 RUN apt-get update -y && \
     apt-get -y install software-properties-common && \
     add-apt-repository -y ppa:deadsnakes/ppa && \
-    apt-get -y install python3.6 \
-                       python3.6-venv \
-                       python3.7 \
-                       python3.7-venv \
-                       python3.8 \
-                       python3.8-venv \
-                       python3.9 \
-                       python3.9-venv \
-                       redis-server \
-                       postgresql-client \
-                       libpq-dev \
-                       sudo \
-                       git
+    DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+        python3.6 \
+        python3.6-venv \
+        python3.7 \
+        python3.7-venv \
+        python3.8 \
+        python3.8-venv \
+        python3.9 \
+        python3.9-venv \
+        redis-server \
+        postgresql-client \
+        libpq-dev \
+        sudo \
+        git
 
 RUN useradd -ms /bin/bash $LOGIN_USER && \
     usermod -aG sudo $LOGIN_USER && \
@@ -35,6 +36,9 @@ RUN python3.9 -m venv /markus_venv && \
     /markus_venv/bin/pip install -r /app/requirements.txt && \
     find /app/autotest_server/testers -name requirements.system -exec {} \; && \
     rm -rf /app/*
+
+# pre-create mount-points for volumes and set ownership of these mountpoints
+RUN mkdir -p /home/docker/.autotesting && chown -R $LOGIN_USER /home/docker/.autotesting
 
 WORKDIR /home/${LOGIN_USER}
 


### PR DESCRIPTION
If the settings are removed for a given test, try to re-install settings before we run the tests.

Problems: this actually creates a concurrency issue that is not handled in the PR and is going to be tricky to manage: 
    - if multiple workers are trying to re-install settings at the same time we can get messy results
    - I think it might be better to just leave it as is and the tests will fail and users can re-install the settings themselves
    - I'm tempted to throw out this PR for the above reasons