### PR TITLE
Fix docker-compose build command to avoid waiting for user input

### DIFF
--- a/server/.dockerfiles/Dockerfile
+++ b/server/.dockerfiles/Dockerfile
@@ -2,6 +2,8 @@ ARG UBUNTU_VERSION
 
 FROM ubuntu:$UBUNTU_VERSION as base
 
+ENV DEBIAN_FRONTEND=noninteractive 
+
 ARG LOGIN_USER
 
 RUN apt-get update -y && \


### PR DESCRIPTION
When running the `docker-compose build autotest` command, it would wait and prompt for user input to set the timezone. This fix makes command avoid prompting for user input so build command can properly run. 
![Autotester Docker not installing](https://user-images.githubusercontent.com/53841219/133103440-14131fbd-d21c-4a9c-a2bd-25d2c9c1c728.png)
