### PR TITLE
Update pyta tester to be compatible with pyta version 2

### DIFF
--- a/server/autotest_server/testers/pyta/requirements.txt
+++ b/server/autotest_server/testers/pyta/requirements.txt
@@ -1,3 +1,3 @@
 python-ta==1.4.2;python_version<"3.8"
-python-ta>=1.5.0;python_version>="3.8"
+python-ta==2.1.0; python_version>="3.8"
 isort<5;python_version<"3.8"


### PR DESCRIPTION
Use pyta's new JSONReporter class to collect data from the test results instead of subclassing PositionReporter.

Note that this requires python-ta version 2.1 (which should be released soon). To test in the meantime replace this line in server/autotest_server/testers/pyta/requirements.txt:

```
python-ta==2.1.0; python_version>="3.8"
```

with 

```
 git+https://github.com/pyta-uoft/pyta.git; python_version>="3.8"
```