### PR TITLE
When a schema doesn't exist, load from an actual json string

### DIFF
--- a/client/autotest_client/__init__.py
+++ b/client/autotest_client/__init__.py
@@ -203,7 +203,7 @@ def reset_credentials(user):
 @app.route("/schema", methods=["GET"])
 @authorize
 def schema(**_kwargs):
-    return json.loads(_redis_connection().get("autotest:schema") or {})
+    return json.loads(_redis_connection().get("autotest:schema") or "{}")
 
 
 @app.route("/settings/<settings_id>", methods=["GET"])


### PR DESCRIPTION
Fixes small bug where no schema existing in the redis DB meant that the fallback was causing an error because it tried to load a json string that wasn't a string. 