### PR TITLE
Keep result object alive for longer 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented here.
 
 ## [unreleased]
+- Keep result object alive for longer than the default 500 seconds (#302)
 
 ## [v2.0.1]
 - Update python-ta tester to be compatible with python-ta version 2 (#296)

--- a/client/autotest_client/__init__.py
+++ b/client/autotest_client/__init__.py
@@ -253,7 +253,12 @@ def run_tests(settings_id, user):
         ids.append(id_)
         data = {"settings_id": settings_id, "test_id": id_, "files_url": url, "categories": categories, "user": user}
         queue.enqueue_call(
-            "autotest_server.run_test", kwargs=data, job_id=str(id_), timeout=int(timeout * 1.5), failure_ttl=3600
+            "autotest_server.run_test",
+            kwargs=data,
+            job_id=str(id_),
+            timeout=int(timeout * 1.5),
+            failure_ttl=3600,
+            result_ttl=3600,
         )  # TODO: make this configurable
 
     return {"test_ids": ids}


### PR DESCRIPTION
This is required to check status. On very large batch jobs it can take much longer than the default (500 seconds) to retrieve a test result.