### PR TITLE
Allow arbitrary kwargs when cancelling tests

### DIFF
--- a/client/autotest_client/__init__.py
+++ b/client/autotest_client/__init__.py
@@ -308,7 +308,7 @@ def get_statuses(settings_id, **_kw):
 
 @app.route("/settings/<settings_id>/tests/cancel", methods=["DELETE"])
 @authorize
-def cancel_tests(settings_id):
+def cancel_tests(settings_id, **_kw):
     test_ids = request.json["test_ids"]
     result = {}
     for id_, job in zip(test_ids, _get_jobs(test_ids, settings_id)):


### PR DESCRIPTION
If the api receives unexpected keyword argument, ignore it instead of raising an error