### PR TITLE
Workspace volume should be initially created as if owned by the login user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ services:
       args:
         UBUNTU_VERSION: '18.04'
         LOGIN_USER: 'docker'
-    image: markus-autotest-server-dev:1.0.0
+        WORKSPACE: '/home/docker/.autotesting'
+    image: markus-autotest-server-dev:1.0.1
     volumes:
       - ./server:/app:cached
       - workspace:/home/docker/.autotesting:rw

--- a/server/.dockerfiles/Dockerfile
+++ b/server/.dockerfiles/Dockerfile
@@ -5,6 +5,7 @@ FROM ubuntu:$UBUNTU_VERSION as base
 ENV DEBIAN_FRONTEND=noninteractive 
 
 ARG LOGIN_USER
+ARG WORKSPACE
 
 RUN apt-get update -y && \
     apt-get -y install software-properties-common && \
@@ -37,6 +38,8 @@ RUN python3.9 -m venv /markus_venv && \
     /markus_venv/bin/pip install -r /app/requirements.txt && \
     find /app/autotest_server/testers -name requirements.system -exec {} \; && \
     rm -rf /app/*
+
+RUN mkdir -p ${WORKSPACE} && chown ${LOGIN_USER} ${WORKSPACE}
 
 WORKDIR /home/${LOGIN_USER}
 


### PR DESCRIPTION
Volumes mounted on the docker container are (now? always?) owned by root if the mount-point doesn't already exist on the container. If it does exist then the directory permissions/ownership is not changed. 

By pre-creating the mount-point we ensure that the permissions are what we want