### PR TITLE
jupyter: Fix test_merge default setting

### DIFF
--- a/server/autotest_server/testers/jupyter/settings_schema.json
+++ b/server/autotest_server/testers/jupyter/settings_schema.json
@@ -55,7 +55,7 @@
                 "test_merge": {
                   "title": "Test that files can be merged",
                   "type": "boolean",
-                  "default": "false"
+                  "default": false
                 }
               }
             },


### PR DESCRIPTION
Currently the Jupyter settings schema sets a default value of `'false'` for `test_merge`. But the field is a boolean, so the default value should be `false` instead.