### PR TITLE
Redirect stdout for r tester

### DIFF
--- a/server/autotest_server/testers/r/lib/r_tester.R
+++ b/server/autotest_server/testers/r/lib/r_tester.R
@@ -1,3 +1,4 @@
+sink(file="/dev/null")
 library(testthat)
 library(rjson)
 args <- commandArgs(TRUE)
@@ -10,4 +11,5 @@ for (i in 1:length(test_results)) {
   }
 }
 json <- toJSON(test_results)
+sink()
 cat(json)


### PR DESCRIPTION
The code under test may write to stdout which would interfere with reporting test results. This redirects stdout to /dev/null while tests are being run so that only the results themselves get reported.