### PR TITLE
Allow whitespace in jupyter tester definitions

### DIFF
--- a/server/autotest_server/testers/jupyter/lib/jupyter_pytest_plugin.py
+++ b/server/autotest_server/testers/jupyter/lib/jupyter_pytest_plugin.py
@@ -63,7 +63,7 @@ class JupyterPlugin:
 
 
 class IpynbFile(pytest.File):
-    TEST_PATTERN = re.compile(r"(?i)^\s*#+\s*(test\w*)\s*$")
+    TEST_PATTERN = re.compile(r"(?i)^\s*#+\s*(test.*?)\s*$")
 
     def collect(self):
         mod = importer.import_from_path(self.fspath)


### PR DESCRIPTION
Previously test cells were defined by an initial comment that started with `test` followed by zero or more word characters. This differed from the documentation that indicated that whitespace characters could also be included. This PR updates the regular expression that is used to find test cells so that whitespace (and any character really) is also accepted.