### PR TITLE
Do not require client to send their own unique username

### DIFF
--- a/client/autotest_client/tests/test_flask_app.py
+++ b/client/autotest_client/tests/test_flask_app.py
@@ -34,4 +34,4 @@ class TestRegister:
 
     def test_with_username(self, client, fake_redis_conn):
         client.post("/register", json={"user_name": "test"})
-        assert "test" in fake_redis_conn.hgetall("autotest:users").values()
+        assert "test" in fake_redis_conn.hgetall("autotest:user_credentials")

--- a/client/autotest_client/tests/test_flask_app.py
+++ b/client/autotest_client/tests/test_flask_app.py
@@ -1,6 +1,7 @@
 import autotest_client
 import pytest
 import fakeredis
+import json
 
 
 @pytest.fixture
@@ -27,11 +28,20 @@ def fake_redis_db(monkeypatch, fake_redis_conn):
 
 
 class TestRegister:
-    def test_no_username(self, client):
-        resp = client.post("/register")
-        assert resp.status_code == 500
-        assert resp.json['message'] == "'NoneType' object is not subscriptable"
 
-    def test_with_username(self, client, fake_redis_conn):
-        client.post("/register", json={"user_name": "test"})
-        assert "test" in fake_redis_conn.hgetall("autotest:user_credentials")
+    @pytest.fixture
+    def credentials(self):
+        return {'auth_type': 'test', 'credentials': '12345'}
+
+    @pytest.fixture
+    def response(self, client, credentials):
+        return client.post("/register", json=credentials)
+
+    def test_status(self, response):
+        assert response.status_code == 200
+
+    def test_api_key_set(self, response):
+        assert response.json['api_key']
+
+    def test_credentials_set(self, response, fake_redis_conn, credentials):
+        assert json.loads(fake_redis_conn.hget('autotest:user_credentials', response.json['api_key'])) == credentials


### PR DESCRIPTION
There is no real need to have the client send a unique username just so we have some key to store credentials under. Clients don't know if their key is going to be unique or not and it's annoying to make them have to guess.

This PR uses the automatically generated unique api key as a key to store user credentials instead. It also makes sure that this api key is actually unique by using redis' hsetnx function (which is atomic).