### PR TITLE
dependabot: Initial commit to enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/client"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: pip
+    directory: "/server"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Add dependabot for automatic dependency update PRs. See https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates.