### PR TITLE
r tester: Fix handling of tests that have an error

### DIFF
--- a/server/autotest_server/testers/r/lib/r_tester.R
+++ b/server/autotest_server/testers/r/lib/r_tester.R
@@ -8,6 +8,13 @@ for (i in 1:length(test_results)) {
     result <- test_results[[i]]$results[[j]]
     expectation <- class(result)[1]
     test_results[[i]]$results[[j]]$type <- expectation
+
+    # If the test raised an error, the $trace attribute of the test result is
+    # a traceback (list of calls). This needs to be pre-formatted because
+    # rjson::toJSON can't handle call objects.
+    if (!is.null(test_results[[i]]$results[[j]]$trace)) {
+      test_results[[i]]$results[[j]]$trace <- format(test_results[[i]]$results[[j]]$trace)
+    }
   }
 }
 json <- toJSON(test_results)


### PR DESCRIPTION
Previous, a test that had an error caused rjson::toJSON output to fail, resulting in no test results stored. After this change, tests with an error are recorded properly using the "error" status.