### PR TITLE
bump flask to 1.1.4

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,4 +1,5 @@
-flask==1.1.2
+flask==1.1.4
+markupsafe==2.0.1
 python-dotenv==0.15.0
 rq==1.7.0
 redis==3.5.3


### PR DESCRIPTION
This change bumps flask to v1.1.4. MarkupSafe also needs to be pinned to a version <=2.0.1 - v2.1.0 removed soft_unicode, which is used in jinja 2.