### PR TITLE
jupyter tester: catch and report notebook syntax errors

### DIFF
--- a/server/autotest_server/testers/jupyter/lib/jupyter_pytest_plugin.py
+++ b/server/autotest_server/testers/jupyter/lib/jupyter_pytest_plugin.py
@@ -99,7 +99,7 @@ class IpynbItem(pytest.Item):
 
     def repr_failure(self, excinfo, style=None):
         for tb in reversed(excinfo.traceback):
-            if tb.frame.code.path == self.mod.__file__:
+            if excinfo.typename == "SyntaxError" or tb.frame.code.path.startswith(self.mod.__file__):
                 err_line = tb.lineno
                 cell_lines = [
                     f"-> {l}" if i == err_line else f"   {l}"


### PR DESCRIPTION
Modifies filter on jupyter pytest plugin to catch and report syntax errors which cause notebook cells not to run as well as runtime errors. Tested in the Markus web interface. Tests to be added.