### PR TITLE
r tester: Fix package name verification for repo sources

### DIFF
--- a/server/autotest_server/testers/r/lib/r_tester_setup.R
+++ b/server/autotest_server/testers/r/lib/r_tester_setup.R
@@ -49,7 +49,7 @@ install_dep <- function(row) {
 
   if (!is.na(remote_type)) {
     install_func <- getFromNamespace(paste("install_", remote_type, sep = ""), "remotes")
-    install_func(name)
+    name <- install_func(name) # install_func returns the package name
   } else if (!is.na(version)) {
     install_version(name, version = paste(compare, version, sep =" "))
   } else {


### PR DESCRIPTION
When specifying a GitHub or other remote dependency for the R tester, the URL for the package name is passed. This causes our post-install check to fail:

https://github.com/MarkUsProject/markus-autotesting/blob/7ccc3324d77eb1723bc803cb0c325c720ffaba28/server/autotest_server/testers/r/lib/r_tester_setup.R#L59-L61

`name` is bound to the URL rather than the package name. Luckily, this is pretty easily fixed because the `remotes::install_*` function family seems to return the package names from the install.