### PR TITLE
bugfix: return error if pyta student file does not exist

### DIFF
--- a/server/autotest_server/testers/pyta/pyta_tester.py
+++ b/server/autotest_server/testers/pyta/pyta_tester.py
@@ -67,6 +67,8 @@ class PytaTest(Test):
         """
         Return a json string containing all test result information.
         """
+        if not os.path.exists(self.student_file):
+            return self.error(message=f'File does not exist: {self.student_file}')
         tmp_stderr = io.StringIO()
         try:
             sys.stderr = tmp_stderr


### PR DESCRIPTION
Previously if pyta was run on a file that does not exist, it returned a perfect score. Instead, this PR checks for the existence of the file and returns an error if it does not exist.