### PR TITLE
Allow client to define environment variables to pass to individual test runs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 - Support dependencies on specific package versions and non-CRAN sources for R tester (#323) 
+- Allow client to define environment variables to pass to individual test runs (#370)
 
 ## [v2.1.0]
 - Add R tester (#310)

--- a/client/autotest_client/__init__.py
+++ b/client/autotest_client/__init__.py
@@ -228,24 +228,33 @@ def update_settings(settings_id, user):
 @app.route("/settings/<settings_id>/test", methods=["PUT"])
 @authorize
 def run_tests(settings_id, user):
-    file_urls = request.json["file_urls"]
+    test_data = request.json["test_data"]
     categories = request.json["categories"]
     high_priority = request.json.get("request_high_priority")
-    queue_name = "batch" if len(file_urls) > 1 else ("high" if high_priority else "low")
+    queue_name = "batch" if len(test_data) > 1 else ("high" if high_priority else "low")
     queue = rq.Queue(queue_name, connection=_rq_connection())
 
     timeout = 0
 
     for settings_ in settings(settings_id)["testers"]:
-        for test_data in settings_["test_data"]:
-            timeout += test_data["timeout"]
+        for data in settings_["test_data"]:
+            timeout += data["timeout"]
 
     ids = []
-    for url in file_urls:
+    for data in test_data:
+        url = data["file_url"]
+        test_env_vars = data.get("env_vars", {})
         id_ = _redis_connection().incr("autotest:tests_id")
         _redis_connection().hset("autotest:tests", key=id_, value=settings_id)
         ids.append(id_)
-        data = {"settings_id": settings_id, "test_id": id_, "files_url": url, "categories": categories, "user": user}
+        data = {
+            "settings_id": settings_id,
+            "test_id": id_,
+            "files_url": url,
+            "categories": categories,
+            "user": user,
+            "test_env_vars": test_env_vars,
+        }
         queue.enqueue_call(
             "autotest_server.run_test",
             kwargs=data,


### PR DESCRIPTION
This change allows clients to pass custom data to be made visible to individual test runs. This works by passing a dictionary of key/value pairs alongside the "file_url" when enqueuing a test run. The server then takes these key/value pairs and passes them to the test process as environment variables. 

This allows client applications to provide information that is visible when running tests that would otherwise not be available by just inspecting the test files and the submitted files. 

This fix is in response to this issue: https://github.com/MarkUsProject/Markus/issues/5087