### PR TITLE
Update flask to version 2.1.2

### DIFF
--- a/client/autotest_client/__init__.py
+++ b/client/autotest_client/__init__.py
@@ -286,7 +286,7 @@ def get_feedback_file(settings_id, tests_id, feedback_id, **_kw):
         abort(make_response(jsonify(message="File doesn't exist"), 404))
     _redis_connection().delete(key)
     return send_file(
-        io.BytesIO(data), mimetype="application/gzip", as_attachment=True, attachment_filename=str(feedback_id)
+        io.BytesIO(data), mimetype="application/gzip", as_attachment=True, download_name=str(feedback_id)
     )
 
 

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,5 +1,4 @@
-flask==1.1.4
-markupsafe==2.0.1
+flask==2.1.2
 python-dotenv==0.20.0
 rq==1.10.1
 redis==4.3.4


### PR DESCRIPTION
- remove pinned version of markupsafe because flask v2 uses the new version of jinja (see issue solved by: #336)
- update argument in `send_file` method 