### PR TITLE
Add ability to clean up test scripts that haven't been used for X days

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented here.
 ## [unreleased]
 - Support dependencies on specific package versions and non-CRAN sources for R tester (#323) 
 - Allow client to define environment variables to pass to individual test runs (#370)
+- Add ability to clean up test scripts that haven't been used for X days (#379)
 
 ## [v2.1.0]
 - Add R tester (#310)

--- a/README.md
+++ b/README.md
@@ -291,3 +291,21 @@ where:
         - if `0 < points_earned < points_total` then `status == "partial"`
         - `status == "error"` if some error occurred that meant the number of points for this test could not be determined
 - `time` is optional (can be null) and is the amount of time it took to run the test (in ms)
+
+## Managing files on disk
+
+Test settings files and virtual environments are created in the `workspace` directory. These files can build up over
+time and are not automatically cleaned up. In order to safely clean up these files, you can use the `clean` command 
+with the `start_stop.sh` script. By calling this script with the optional `--age` argument, settings files and virtual
+environments older than X days will be deleted safely. For example
+
+```shell
+autotest:/$ python3 markus-autotesting/server/start_stop.py clean --age 30
+```
+
+will delete settings that have not been accessed (updated or used to run a test) in the last 30 days.
+
+To see which settings *would be* deleted without actually deleting them, use the optional `--dry-run` flag as well.
+
+Users who try to run tests after the settings have been cleaned up in this manner will see an error message telling them
+that the test settings have expired and prompting them to upload more.

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -327,6 +327,8 @@ def run_test(settings_id, test_id, files_url, categories, user, test_env_vars):
     error = None
     try:
         settings = json.loads(redis_connection().hget("autotest:settings", key=settings_id))
+        settings["_last_access"] = int(time.time())
+        redis_connection().hset("autotest:settings", key=settings_id, value=json.dumps(settings))
         test_username, tests_path = tester_user()
         try:
             _setup_files(settings_id, user, files_url, tests_path, test_username)
@@ -393,4 +395,5 @@ def update_test_settings(user, settings_id, test_settings, file_url):
         raise
     finally:
         test_settings["_user"] = user
+        test_settings["_last_access"] = int(time.time())
         redis_connection().hset("autotest:settings", key=settings_id, value=json.dumps(test_settings))

--- a/server/start_stop.py
+++ b/server/start_stop.py
@@ -1,5 +1,9 @@
 import argparse
+import json
 import os
+import shutil
+import time
+import redis
 import sys
 import signal
 import subprocess
@@ -10,6 +14,8 @@ _PID_FILE = os.path.join(_THIS_DIR, "supervisord.pid")
 _CONF_FILE = os.path.join(_THIS_DIR, "supervisord.conf")
 _SUPERVISORD = os.path.join(os.path.dirname(sys.executable), "supervisord")
 _RQ = os.path.join(os.path.dirname(sys.executable), "rq")
+
+SECONDS_PER_DAY = 86400
 
 HEADER = f"""[supervisord]
 
@@ -36,6 +42,10 @@ stopasgroup=true
 killasgroup=true
 
 """
+
+
+def redis_connection() -> redis.Redis:
+    return redis.Redis.from_url(config["redis_url"], decode_responses=True)
 
 
 def create_enqueuer_wrapper():
@@ -71,6 +81,23 @@ def stat(extra_args):
     subprocess.run([_RQ, "info", "--url", config["redis_url"], *extra_args], check=True)
 
 
+def clean(age, dry_run):
+    for settings_id, settings in dict(redis_connection().hgetall("autotest:settings") or {}).items():
+        settings = json.loads(settings)
+        last_access_timestamp = settings.get("_last_access")
+        access = int(time.time() - (last_access_timestamp or 0))
+        if last_access_timestamp is None or (access > (age * SECONDS_PER_DAY)):
+            dir_path = os.path.join(config["workspace"], "scripts", str(settings_id))
+            if dry_run and os.path.isdir(dir_path):
+                last_access = "UNKNOWN" if last_access_timestamp is None else access // SECONDS_PER_DAY
+                print(f"{dir_path} -> last accessed {last_access or '< 1'} days ago")
+            else:
+                settings["_error"] = "the settings for this test have expired, please re-upload the settings."
+                redis_connection().hset("autotest:settings", key=settings_id, value=json.dumps(settings))
+                if os.path.isdir(dir_path):
+                    shutil.rmtree(dir_path)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command")
@@ -79,6 +106,14 @@ if __name__ == "__main__":
     subparsers.add_parser("stop", help="stop the autotester")
     subparsers.add_parser("restart", help="restart the autotester")
     subparsers.add_parser("stat", help="display current status of the autotester queues")
+    clean_parser = subparsers.add_parser("clean", help="clean up old/unused test scripts")
+
+    clean_parser.add_argument(
+        "-a", "--age", default=0, type=int, help="clean up tests older than <age> in days. Default=0"
+    )
+    clean_parser.add_argument(
+        "-d", "--dry-run", action="store_true", help="list files that will be deleted without actually removing them"
+    )
 
     args, remainder = parser.parse_known_args()
     if args.command == "start":
@@ -90,3 +125,5 @@ if __name__ == "__main__":
         start(remainder)
     elif args.command == "stat":
         stat(remainder)
+    elif args.command == "clean":
+        clean(args.age, args.dry_run)


### PR DESCRIPTION
Test scripts that haven't been used recently can be cleaned up using the `clean` command to the `start_stop.sh` script. Users who try to run tests against these cleaned test scripts will see an error message prompting them to re-upload the test scripts again.