### PR TITLE
Update configurations for flask settings

### DIFF
--- a/client/.flaskenv
+++ b/client/.flaskenv
@@ -1,2 +1,0 @@
-FLASK_ENV=development
-FLASK_APP=autotest_client

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,4 +1,4 @@
-flask==2.1.3
+flask==2.2.1
 python-dotenv==0.20.0
 rq==1.11.0
 redis==4.3.4

--- a/client/run.py
+++ b/client/run.py
@@ -2,4 +2,4 @@ import os
 from autotest_client import app
 
 if __name__ == "__main__":
-    app.run(host=os.environ["FLASK_HOST"], port=int(os.environ["FLASK_PORT"]))
+    app.run(host=os.environ["FLASK_HOST"], port=int(os.environ["FLASK_PORT"]), debug=True)


### PR DESCRIPTION
Remove deprecated settings after updating to flask 2.2 (most of these will be removed in 2.3 but show warnings for now)