### PR TITLE
namespace R test runner script

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 - Remove support for python3.6 and add support for python3.10 (#399)
+- Add explicit namespaces to R test runner script so that test code will not interfere with result reporting (#407)
 
 ## [v2.2.1]
 - Raise error if rq or supervisord executables can't be found when running start_stop.py (#390)

--- a/server/autotest_server/testers/r/lib/r_tester.R
+++ b/server/autotest_server/testers/r/lib/r_tester.R
@@ -2,7 +2,7 @@ sink(file="/dev/null")
 library(testthat)
 library(rjson)
 args <- commandArgs(TRUE)
-test_results <- test_file(args[1], reporter = ListReporter)
+test_results <- testthat::test_file(args[1], reporter = testthat::ListReporter)
 for (i in 1:length(test_results)) {
   for (j in 1:length(test_results[[i]]$results)) {
     result <- test_results[[i]]$results[[j]]
@@ -17,6 +17,6 @@ for (i in 1:length(test_results)) {
     }
   }
 }
-json <- toJSON(test_results)
+json <- rjson::toJSON(test_results)
 sink()
 cat(json)


### PR DESCRIPTION
Libraries loaded in file tested by testthat (by running the `testthat::test_file`) become available in the main namespace of the r_tester.R file. This means that if there is a conflicting name/function, the r_tester.R file may use the wrong one. 

For example, r_tester.R uses the rjson library, if a file under test loads the jsonlite library, then the `toJSON` of the jsonlite library will be used to display test results. Since jsonlite can't serialize testthat_result objects (but rjson can), an error is raised.

To avoid this, this PR uses explicit namespaces to make sure the right version of files are used. 

Note that the `rjson::` addition is necessary but the `testthat::` additions are not strictly necessary because they will always be executed before the file under test is loaded/run. However, I added them to be explicit and to future-proof this file in case we ever change it to run multiple test files.