### PR TITLE
Use a single redis connection per process

### DIFF
--- a/client/autotest_client/tests/test_flask_app.py
+++ b/client/autotest_client/tests/test_flask_app.py
@@ -13,18 +13,12 @@ def client():
 
 @pytest.fixture
 def fake_redis_conn():
-    yield fakeredis.FakeStrictRedis(decode_responses=True)
-
-
-@pytest.fixture
-def fake_rq_conn():
-    conn = fakeredis.FakeStrictRedis(decode_responses=False)
-    autotest_client.rq.use_connection(conn)
+    yield fakeredis.FakeStrictRedis()
 
 
 @pytest.fixture(autouse=True)
 def fake_redis_db(monkeypatch, fake_redis_conn):
-    monkeypatch.setattr(autotest_client.redis.Redis, "from_url", lambda *a, **kw: fake_redis_conn)
+    monkeypatch.setattr(autotest_client, "REDIS_CONNECTION", fake_redis_conn)
 
 
 class TestRegister:

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -13,6 +13,7 @@ import redis
 import importlib
 import psycopg2
 import mimetypes
+import rq
 from typing import Optional, Dict, Union, List, Tuple, Callable, Type
 from types import TracebackType
 
@@ -20,14 +21,13 @@ from .config import config
 from .utils import loads_partial_json, set_rlimits_before_test, extract_zip_stream, recursive_iglob, copy_tree
 
 DEFAULT_ENV_DIR = "defaultvenv"
-REDIS_URL = config["redis_url"]
 TEST_SCRIPT_DIR = os.path.join(config["workspace"], "scripts")
 
 ResultData = Dict[str, Union[str, int, type(None), Dict]]
 
 
 def redis_connection() -> redis.Redis:
-    return redis.Redis.from_url(REDIS_URL, decode_responses=True)
+    return rq.get_current_job().connection
 
 
 def run_test_command(test_username: Optional[str] = None) -> str:

--- a/server/autotest_server/tests/test_autotest_server.py
+++ b/server/autotest_server/tests/test_autotest_server.py
@@ -1,16 +1,27 @@
 import pytest
 import fakeredis
+import rq
 import autotest_server
 
 
 @pytest.fixture
 def fake_redis_conn():
-    yield fakeredis.FakeStrictRedis(decode_responses=True)
+    yield fakeredis.FakeStrictRedis()
+
+
+@pytest.fixture
+def fake_queue(fake_redis_conn):
+    yield rq.Queue(is_async=False, connection=fake_redis_conn)
+
+
+@pytest.fixture
+def fake_job(fake_queue):
+    yield fake_queue.enqueue(lambda: None)
 
 
 @pytest.fixture(autouse=True)
-def fake_redis_db(monkeypatch, fake_redis_conn):
-    monkeypatch.setattr(autotest_server.redis.Redis, "from_url", lambda *a, **kw: fake_redis_conn)
+def fake_redis_db(monkeypatch, fake_job):
+    monkeypatch.setattr(autotest_server.rq, "get_current_job", lambda *a, **kw: fake_job)
 
 
 def test_redis_connection(fake_redis_conn):

--- a/server/install.py
+++ b/server/install.py
@@ -7,6 +7,7 @@ import grp
 import json
 import subprocess
 import getpass
+import redis
 from autotest_server.config import config
 from autotest_server import run_test_command
 from autotest_server.testers import install as install_testers

--- a/server/install.py
+++ b/server/install.py
@@ -8,8 +8,10 @@ import json
 import subprocess
 import getpass
 from autotest_server.config import config
-from autotest_server import redis_connection, run_test_command
+from autotest_server import run_test_command
 from autotest_server.testers import install as install_testers
+
+REDIS_CONNECTION = redis.Redis.from_url(config["redis_url"])
 
 
 def _print(*args, **kwargs):
@@ -19,7 +21,7 @@ def _print(*args, **kwargs):
 def check_dependencies():
     _print("checking if redis url is valid:")
     try:
-        redis_connection().keys()
+        REDIS_CONNECTION.ping()
     except Exception as e:
         raise Exception(f'Cannot connect to redis database with url: {config["redis_url"]}') from e
     for w in config["workers"]:
@@ -66,7 +68,7 @@ def install_all_testers():
         skeleton = json.load(f)
         skeleton["definitions"]["installed_testers"]["enum"] = list(settings.keys())
         skeleton["definitions"]["tester_schemas"]["oneOf"] = list(settings.values())
-        redis_connection().set("autotest:schema", json.dumps(skeleton))
+        REDIS_CONNECTION.set("autotest:schema", json.dumps(skeleton))
 
 
 def install():

--- a/server/start_stop.py
+++ b/server/start_stop.py
@@ -43,9 +43,7 @@ killasgroup=true
 
 """
 
-
-def redis_connection() -> redis.Redis:
-    return redis.Redis.from_url(config["redis_url"], decode_responses=True)
+REDIS_CONNECTION = redis.Redis.from_url(config["redis_url"], decode_responses=True)
 
 
 def create_enqueuer_wrapper(rq):
@@ -82,7 +80,7 @@ def stat(rq, extra_args):
 
 
 def clean(age, dry_run):
-    for settings_id, settings in dict(redis_connection().hgetall("autotest:settings") or {}).items():
+    for settings_id, settings in dict(REDIS_CONNECTION.hgetall("autotest:settings") or {}).items():
         settings = json.loads(settings)
         last_access_timestamp = settings.get("_last_access")
         access = int(time.time() - (last_access_timestamp or 0))
@@ -93,7 +91,7 @@ def clean(age, dry_run):
                 print(f"{dir_path} -> last accessed {last_access or '< 1'} days ago")
             else:
                 settings["_error"] = "the settings for this test have expired, please re-upload the settings."
-                redis_connection().hset("autotest:settings", key=settings_id, value=json.dumps(settings))
+                REDIS_CONNECTION.hset("autotest:settings", key=settings_id, value=json.dumps(settings))
                 if os.path.isdir(dir_path):
                     shutil.rmtree(dir_path)
 


### PR DESCRIPTION
In order to reduce the number of total redis connections used by the autotester:

- use a single redis connection by each of the API (client) processes. This is declared as a global variable
- use the _same_ redis connection used by the rq job in each worker process
- use a single redis connection in the installer script
- use a single redis connection in the start_stop script

Note that in the API, two types of connection were previously required: one that decoded all responses and another that did not. In order to use a single connection, the code that assumed that responses are decoded are updated to handle decoding as needed. 