### PR TITLE
Remove need to skip top level directories

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 - Remove support for python3.6 and add support for python3.10 (#399)
+- Remove requirement to skip top level directory in zip archive when downloading test files (#412)
 
 ## [v2.2.2]
 - Fix a bug in the java tester where errors were not reported (#401)

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -278,7 +278,7 @@ def _setup_files(settings_id: int, user: str, files_url: str, tests_path: str, t
     """
     creds = json.loads(redis_connection().hget("autotest:user_credentials", key=user))
     r = requests.get(files_url, headers={"Authorization": f"{creds['auth_type']} {creds['credentials']}"})
-    extract_zip_stream(r.content, tests_path, ignore_root_dirs=1)
+    extract_zip_stream(r.content, tests_path)
     for fd, file_or_dir in recursive_iglob(tests_path):
         if fd == "d":
             os.chmod(file_or_dir, 0o770)
@@ -366,7 +366,7 @@ def update_test_settings(user, settings_id, test_settings, file_url):
         os.makedirs(files_dir, exist_ok=True)
         creds = json.loads(redis_connection().hget("autotest:user_credentials", key=user))
         r = requests.get(file_url, headers={"Authorization": f"{creds['auth_type']} {creds['credentials']}"})
-        extract_zip_stream(r.content, files_dir, ignore_root_dirs=0)
+        extract_zip_stream(r.content, files_dir)
 
         schema = json.loads(redis_connection().get("autotest:schema"))
         installed_testers = schema["definitions"]["installed_testers"]["enum"]

--- a/server/autotest_server/utils.py
+++ b/server/autotest_server/utils.py
@@ -72,17 +72,14 @@ def set_rlimits_before_test() -> None:
         resource.setrlimit(limit, (soft, hard))
 
 
-def extract_zip_stream(zip_byte_stream: bytes, destination: str, ignore_root_dirs: int = 1) -> None:
+def extract_zip_stream(zip_byte_stream: bytes, destination: str) -> None:
     """
     Extract files in a zip archive's content <zip_byte_stream> to <destination>, a path to a local directory.
-
-    If ignore_root_dir is a positive integer, the files in the zip archive will be extracted and written as if
-    the top n root directories of the zip archive were not in their path (where n == ignore_root_dirs).
     """
     with zipfile.ZipFile(BytesIO(zip_byte_stream)) as zf:
         for fname in zf.namelist():
             *dpaths, bname = fname.split(os.sep)
-            dest = os.path.join(destination, *dpaths[ignore_root_dirs:])
+            dest = os.path.join(destination, dpaths)
             filename = os.path.join(dest, bname)
             if filename.endswith("/"):
                 os.makedirs(filename, exist_ok=True)


### PR DESCRIPTION
When https://github.com/MarkUsProject/Markus/pull/6323 gets pulled in, we will no longer need to support the fact that MarkUs provides content of zip files in two different ways (one with an extra subfolder, one without).

This is one of the last steps to fully decoupling MarkUs from the autotester.