### PR TITLE
Update docker-compose.yml network settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,5 +77,5 @@ volumes:
 
 networks:
   markus_dev:
-    external:
-      name: markus_dev
+    name: markus_dev
+    external: true


### PR DESCRIPTION
Looks like the `external` network key was deprecated: https://github.com/docker/compose-cli/issues/1856.