### PR TITLE
bump python-ta to 2.6.2

### DIFF
--- a/server/autotest_server/testers/pyta/requirements.txt
+++ b/server/autotest_server/testers/pyta/requirements.txt
@@ -1,3 +1,3 @@
 python-ta==1.4.2;python_version<"3.8"
-python-ta==2.6.1; python_version>="3.8"
+python-ta==2.6.2; python_version>="3.8"
 isort<5;python_version<"3.8"


### PR DESCRIPTION
This PR bumps [`python-ta`](https://pypi.org/project/python-ta/#description) to the latest version,  `2.6.2`.