### PR TITLE
Ensure test results are reported when feedback files are missing AB#118

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 
+- Fix bug that prevented test results from being returned when a feedback file could not be found (#458)
+
 ## [v2.3.1]
 - Fix a bug that prevented test file from being copied from a zip file to another location on disk (#426)
 

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -236,8 +236,8 @@ def _run_test_specs(
                     extra_info = test_data.get("extra_info", {})
                     feedback, feedback_errors = _get_feedback(test_data, tests_path, test_id)
                     if feedback_errors:
-                      msg = 'Cannot find feedback file(s): ' + ', '.join(feedback_errors)
-                      err = err + '\n\n' + msg if err else msg
+                        msg = "Cannot find feedback file(s): " + ", ".join(feedback_errors)
+                        err = err + "\n\n" + msg if err else msg
                     results.append(_create_test_group_result(out, err, duration, extra_info, feedback, timeout_expired))
     return results
 

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import sys
 import shutil
@@ -134,9 +135,9 @@ def _get_env_vars(test_username: str) -> Dict[str, str]:
     return env_vars
 
 
-def _get_feedback(test_data, tests_path, test_id):
+def _get_feedback(test_data, tests_path, test_id) -> tuple[dict, str]:
     feedback_files = test_data.get("feedback_file_names", [])
-    feedback = []
+    feedback, feedback_errors = [], []
     for feedback_file in feedback_files:
         feedback_path = os.path.join(tests_path, feedback_file)
         if os.path.isfile(feedback_path):
@@ -155,8 +156,8 @@ def _get_feedback(test_data, tests_path, test_id):
                     }
                 )
         else:
-            raise Exception(f"Cannot find feedback file at '{feedback_path}'.")
-    return feedback
+            feedback_errors.append(feedback_file)
+    return feedback, feedback_errors
 
 
 def _update_env_vars(base_env: Dict, test_env: Dict) -> Dict:
@@ -233,7 +234,10 @@ def _run_test_specs(
                 finally:
                     duration = int(round(time.time() - start, 3) * 1000)
                     extra_info = test_data.get("extra_info", {})
-                    feedback = _get_feedback(test_data, tests_path, test_id)
+                    feedback, feedback_errors = _get_feedback(test_data, tests_path, test_id)
+                    if feedback_errors:
+                      msg = 'Cannot find feedback file(s): ' + ', '.join(feedback_errors)
+                      err = err + '\n\n' + msg if err else msg
                     results.append(_create_test_group_result(out, err, duration, extra_info, feedback, timeout_expired))
     return results
 


### PR DESCRIPTION
Previously, if a feedback file was not generated by a test run, the autotester would fail to send back test results.

I have changed this so that the autotester sends the test results but also reports the missing feedback files in an error message.