### PR TITLE
Bump jsonschema from 4.16.0 to 4.20.0

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -2,6 +2,7 @@ flask==2.2.2
 python-dotenv==0.21.0
 rq==1.11.1
 redis==5.0.1
-jsonschema==4.16.0
+jsonschema==4.17.3;python_version<"3.8"
+jsonschema==4.20.0;python_version>="3.8"
 Werkzeug==2.2.3;python_version<"3.8"
 Werkzeug==2.3.7;python_version>="3.8"

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,7 +2,8 @@ rq==1.11.1
 click==8.1.3
 redis==5.0.1
 pyyaml==6.0
-jsonschema==4.16.0
+jsonschema==4.17.3;python_version<"3.8"
+jsonschema==4.20.0;python_version>="3.8"
 requests==2.28.1
 psycopg2-binary==2.9.5
 supervisor==4.2.4


### PR DESCRIPTION
Release notes: https://github.com/python-jsonschema/jsonschema/releases
Commits: https://github.com/python-jsonschema/jsonschema/compare/v4.16.0...v4.20.0

Closes #416 and closes #417.