### PR TITLE
Update docker images to use Python 3.11 and include Python 3.12

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -13,6 +13,8 @@ jobs:
           - 3.8
           - 3.9
           - '3.10'
+          - 3.11
+          - 3.12
         test-dir:
           - client
           - server

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented here.
 ## [unreleased]
 
 - Fix bug that prevented test results from being returned when a feedback file could not be found (#458)
+- Add support for Python 3.11 and 3.12 (#467)
 
 ## [v2.3.1]
 - Fix a bug that prevented test file from being copied from a zip file to another location on disk (#426)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Both the autotester and the API are designed to be run on Ubuntu 20.04 (or suffi
 6. [Configure the autotester](#autotester-configuration-options)
 7. Optionally install additional python versions.
    
-   The `py` (python3) and `pyta` testers can be run using any version of python between versions 3.7 and 3.10. When
+   The `py` (python3) and `pyta` testers can be run using any version of python between versions 3.7 and 3.12. When
    these testers are installed the autotester will search the PATH for available python executables. If you want users
    to be able to run tests with a specific python version, ensure that it is visible in the PATH of both the user running
    the autotester and all users who run tests.

--- a/client/.dockerfiles/Dockerfile
+++ b/client/.dockerfiles/Dockerfile
@@ -2,11 +2,14 @@ ARG UBUNTU_VERSION
 
 FROM ubuntu:$UBUNTU_VERSION
 
-RUN apt-get update -y && apt-get install -y python3 python3-venv
+RUN apt-get update -y && \
+    apt-get -y install software-properties-common && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get install -y python3.11 python3.11-venv
 
 COPY ./requirements.txt /requirements.txt
 
-RUN python3 -m venv /markus_venv && \
+RUN python3.11 -m venv /markus_venv && \
     /markus_venv/bin/pip install wheel && \
     /markus_venv/bin/pip install -r /requirements.txt
 

--- a/server/.dockerfiles/Dockerfile
+++ b/server/.dockerfiles/Dockerfile
@@ -18,6 +18,10 @@ RUN apt-get update -y && \
                        python3.9-venv \
                        python3.10 \
                        python3.10-venv \
+                       python3.11 \
+                       python3.11-venv \
+                       python3.12 \
+                       python3.12-venv \
                        redis-server \
                        postgresql-client \
                        libpq-dev \
@@ -34,7 +38,7 @@ RUN useradd -ms /bin/bash $LOGIN_USER && \
 
 COPY . /app
 
-RUN python3.10 -m venv /markus_venv && \
+RUN python3.11 -m venv /markus_venv && \
     /markus_venv/bin/pip install wheel && \
     /markus_venv/bin/pip install -r /app/requirements.txt && \
     find /app/autotest_server/testers -name requirements.system -exec {} \; && \

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,7 +1,7 @@
 rq==1.15.1
 click==8.1.3
 redis==5.0.1
-pyyaml==6.0
+pyyaml==6.0.1
 jsonschema==4.17.3;python_version<"3.8"
 jsonschema==4.20.0;python_version>="3.8"
 requests==2.31.0


### PR DESCRIPTION
The autotest server image now includes Python 3.7 to 3.12, and run the autotest server code using Python 3.11.

The autotest client image now includes Python 3.11, and runs the client code using that version.