### PR TITLE
Track test environment setup in redis

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented here.
 
 - Fix bug that prevented test results from being returned when a feedback file could not be found (#458)
 - Add support for Python 3.11 and 3.12 (#467)
+- Track test environment setup status and report errors when running tests if environment setup is in progress or raised an error (#468)
 
 ## [v2.3.1]
 - Fix a bug that prevented test file from being copied from a zip file to another location on disk (#426)


### PR DESCRIPTION
Currently the autotester does not keep track of the status of test environment creation (mostly, installing test dependencies). In particular, a MarkUs user is able to run tests even when not all dependencies are installed, likely resulting in tests failing with some kind of "import error".

This PR introduces a new `_env_status` attribute in the Redis store for test settings to track the status of environment creation. This attribute has three possible values:

- `setup`: the environment is being set up (tests will not be run)
- `ready`: setup is complete and tests can now be run
- `error`: there was an error during environment setup (tests will not be run) 