### PR TITLE
Update Haskell tester to use Stack

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented here.
 - Fix bug that prevented test results from being returned when a feedback file could not be found (#458)
 - Add support for Python 3.11 and 3.12 (#467)
 - Track test environment setup status and report errors when running tests if environment setup is in progress or raised an error (#468)
+- Update Haskell tester to use [Stack](https://docs.haskellstack.org/en/stable/) to install dependencies (#469)
 
 ## [v2.3.1]
 - Fix a bug that prevented test file from being copied from a zip file to another location on disk (#426)

--- a/server/autotest_server/testers/haskell/haskell_tester.py
+++ b/server/autotest_server/testers/haskell/haskell_tester.py
@@ -7,11 +7,8 @@ from typing import Dict, Type, List, Iterator, Union
 from ..tester import Tester, Test, TestError
 from ..specs import TestSpecs
 
-STACK_OPTIONS = [
-    '--resolver=lts-14.27',
-    '--system-ghc',
-    '--allow-different-user'
-]
+STACK_OPTIONS = ["--resolver=lts-14.27", "--system-ghc", "--allow-different-user"]
+
 
 class HaskellTest(Test):
     def __init__(
@@ -110,24 +107,22 @@ class HaskellTester(Tester):
         for test_file in self.specs["test_data", "script_files"]:
             with tempfile.NamedTemporaryFile(dir=this_dir) as f:
                 cmd = [
-                  "stack",
-                  "exec",
-                  *STACK_OPTIONS,
-                  "--",
-                  "tasty-discover",
-                  ".",
-                  "_",
-                  f.name,
-                  *self._test_run_flags(test_file)
+                    "stack",
+                    "exec",
+                    *STACK_OPTIONS,
+                    "--",
+                    "tasty-discover",
+                    ".",
+                    "_",
+                    f.name,
+                    *self._test_run_flags(test_file),
                 ]
                 subprocess.run(cmd, stdout=subprocess.DEVNULL, universal_newlines=True, check=True)
                 with tempfile.NamedTemporaryFile(mode="w+", dir=this_dir) as sf:
-                    cmd = ["stack", "runghc",
-                           *STACK_OPTIONS,
-                           "--",
-                           f"-i={haskell_lib}", f.name, f"--stats={sf.name}"]
-                    subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, universal_newlines=True,
-                                   check=True)
+                    cmd = ["stack", "runghc", *STACK_OPTIONS, "--", f"-i={haskell_lib}", f.name, f"--stats={sf.name}"]
+                    subprocess.run(
+                        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, universal_newlines=True, check=True
+                    )
                     results[test_file] = self._parse_test_results(csv.reader(sf))
         return results
 

--- a/server/autotest_server/testers/haskell/haskell_tester.py
+++ b/server/autotest_server/testers/haskell/haskell_tester.py
@@ -7,6 +7,11 @@ from typing import Dict, Type, List, Iterator, Union
 from ..tester import Tester, Test, TestError
 from ..specs import TestSpecs
 
+STACK_OPTIONS = [
+    '--resolver=lts-14.27',
+    '--system-ghc',
+    '--allow-different-user'
+]
 
 class HaskellTest(Test):
     def __init__(
@@ -104,11 +109,25 @@ class HaskellTester(Tester):
         haskell_lib = os.path.join(os.path.dirname(os.path.realpath(__file__)), "lib")
         for test_file in self.specs["test_data", "script_files"]:
             with tempfile.NamedTemporaryFile(dir=this_dir) as f:
-                cmd = ["tasty-discover", ".", "_", f.name] + self._test_run_flags(test_file)
+                cmd = [
+                  "stack",
+                  "exec",
+                  *STACK_OPTIONS,
+                  "--",
+                  "tasty-discover",
+                  ".",
+                  "_",
+                  f.name,
+                  *self._test_run_flags(test_file)
+                ]
                 subprocess.run(cmd, stdout=subprocess.DEVNULL, universal_newlines=True, check=True)
                 with tempfile.NamedTemporaryFile(mode="w+", dir=this_dir) as sf:
-                    cmd = ["runghc", "--", f"-i={haskell_lib}", f.name, f"--stats={sf.name}"]
-                    subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, universal_newlines=True)
+                    cmd = ["stack", "runghc",
+                           *STACK_OPTIONS,
+                           "--",
+                           f"-i={haskell_lib}", f.name, f"--stats={sf.name}"]
+                    subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, universal_newlines=True,
+                                   check=True)
                     results[test_file] = self._parse_test_results(csv.reader(sf))
         return results
 

--- a/server/autotest_server/testers/haskell/requirements.system
+++ b/server/autotest_server/testers/haskell/requirements.system
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
 
-if ! dpkg -l ghc cabal-install &> /dev/null; then
+if ! dpkg -l ghc cabal-install haskell-stack &> /dev/null; then
   apt-get -y update
-  DEBIAN_FRONTEND=noninteractive apt-get install -y -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' ghc cabal-install
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' ghc cabal-install haskell-stack
 fi
 
-# TODO: install these without cabal so they can be properly isolated/uninstalled
-cabal update
-ghc-pkg describe tasty-discover &>/dev/null || cabal install tasty-discover --global
-ghc-pkg describe tasty-quickcheck &>/dev/null || cabal install tasty-quickcheck --global
+stack update

--- a/server/autotest_server/testers/haskell/setup.py
+++ b/server/autotest_server/testers/haskell/setup.py
@@ -3,7 +3,23 @@ import json
 import subprocess
 
 
+HASKELL_TEST_DEPS = [
+    "tasty-discover",
+    "tasty-quickcheck"
+]
+
 def create_environment(_settings, _env_dir, default_env_dir):
+    resolver = "lts-14.27"
+    cmd = [
+        "stack",
+        "build",
+        "--resolver",
+        resolver,
+        "--system-ghc",
+        *HASKELL_TEST_DEPS
+    ]
+    subprocess.run(cmd, check=True)
+
     return {"PYTHON": os.path.join(default_env_dir, "bin", "python3")}
 
 

--- a/server/autotest_server/testers/haskell/setup.py
+++ b/server/autotest_server/testers/haskell/setup.py
@@ -3,21 +3,12 @@ import json
 import subprocess
 
 
-HASKELL_TEST_DEPS = [
-    "tasty-discover",
-    "tasty-quickcheck"
-]
+HASKELL_TEST_DEPS = ["tasty-discover", "tasty-quickcheck"]
+
 
 def create_environment(_settings, _env_dir, default_env_dir):
     resolver = "lts-14.27"
-    cmd = [
-        "stack",
-        "build",
-        "--resolver",
-        resolver,
-        "--system-ghc",
-        *HASKELL_TEST_DEPS
-    ]
+    cmd = ["stack", "build", "--resolver", resolver, "--system-ghc", *HASKELL_TEST_DEPS]
     subprocess.run(cmd, check=True)
 
     return {"PYTHON": os.path.join(default_env_dir, "bin", "python3")}


### PR DESCRIPTION
There was an issue with inconsistencies in package dependencies on the teach.cs production autotesting servers this semester. 

This pull request modifies the Haskell tester setup to use [Stack](https://docs.haskellstack.org/en/stable/), and the [lts-14.27](https://www.stackage.org/lts-14.27) snapshot to pin specific dependencies.

As a comment, lts-14.27 was chosen to be consistent with the previous Haskell installation, but it's quite old. Future work would involve upgrading dependencies to new snapshots (and versions of the GHC compiler).