### PR TITLE
Ensure that Python 3.11 and Python 3.12 are available to Python/PyTA/Jupyter testers

### DIFF
--- a/server/autotest_server/testers/jupyter/setup.py
+++ b/server/autotest_server/testers/jupyter/setup.py
@@ -18,7 +18,7 @@ def create_environment(settings_, env_dir, _default_env_dir):
 def settings():
     with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), "settings_schema.json")) as f:
         settings_ = json.load(f)
-    py_versions = [f"3.{x}" for x in range(7, 11) if shutil.which(f"python3.{x}")]
+    py_versions = [f"3.{x}" for x in range(7, 13) if shutil.which(f"python3.{x}")]
     python_versions = settings_["properties"]["env_data"]["properties"]["python_version"]
     python_versions["enum"] = py_versions
     python_versions["default"] = py_versions[-1]

--- a/server/autotest_server/testers/py/setup.py
+++ b/server/autotest_server/testers/py/setup.py
@@ -18,7 +18,7 @@ def create_environment(settings_, env_dir, _default_env_dir):
 def settings():
     with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), "settings_schema.json")) as f:
         settings_ = json.load(f)
-    py_versions = [f"3.{x}" for x in range(7, 11) if shutil.which(f"python3.{x}")]
+    py_versions = [f"3.{x}" for x in range(7, 13) if shutil.which(f"python3.{x}")]
     python_versions = settings_["properties"]["env_data"]["properties"]["python_version"]
     python_versions["enum"] = py_versions
     python_versions["default"] = py_versions[-1]

--- a/server/autotest_server/testers/pyta/setup.py
+++ b/server/autotest_server/testers/pyta/setup.py
@@ -18,7 +18,7 @@ def create_environment(settings_, env_dir, _default_env_dir):
 def settings():
     with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), "settings_schema.json")) as f:
         settings_ = json.load(f)
-    py_versions = [f"3.{x}" for x in range(7, 11) if shutil.which(f"python3.{x}")]
+    py_versions = [f"3.{x}" for x in range(7, 13) if shutil.which(f"python3.{x}")]
     python_versions = settings_["properties"]["env_data"]["properties"]["python_version"]
     python_versions["enum"] = py_versions
     python_versions["default"] = py_versions[-1]


### PR DESCRIPTION
While #467 ensured that Python 3.11/3.12 are installed in development, a separate check is necessary to ensure that these versions are part of the autotest settings schema sent to MarkUs.