### PR TITLE
Improve default error message when a test group times out

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented here.
 - Add support for Python 3.11 and 3.12 (#467)
 - Track test environment setup status and report errors when running tests if environment setup is in progress or raised an error (#468)
 - Update Haskell tester to use [Stack](https://docs.haskellstack.org/en/stable/) to install dependencies (#469)
+- Improve default error message when a test group times out (#470)
 
 ## [v2.3.1]
 - Fix a bug that prevented test file from being copied from a zip file to another location on disk (#426)

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -229,6 +229,12 @@ def _run_test_specs(
                         else:
                             _kill_user_processes(test_username)
                         out, err = proc.communicate()
+                        if err == "Killed\n":  # Default message from shell
+                            test_group_name = test_data.get("extra_info", {}).get("name", "").strip()
+                            if test_group_name:
+                                err = f"Tests for {test_group_name} did not complete within time limit ({timeout}s)\n"
+                            else:
+                                err = f"Tests did not complete within time limit ({timeout}s)\n"
                         timeout_expired = timeout
                 except Exception as e:
                     err += "\n\n{}".format(e)


### PR DESCRIPTION
Currently if a test group reaches the timeout limit, the test process is killed and the shell default `'Killed\n'` message is written to stderr. This is communicated as part of the test results and displayed in MarkUs.

I have replaced this error message with a more descriptive error message.