### PR TITLE
unset sticky bit when clearing working directory

### DIFF
--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -254,9 +254,9 @@ def _clear_working_directory(tests_path: str, test_username: str) -> None:
     Run commands that clear the tests_path working directory
     """
     if test_username != getpass.getuser():
-        chmod_cmd = f"sudo -u {test_username} -- bash -c 'chmod -Rf ugo+rwX {tests_path}'"
+        chmod_cmd = f"sudo -u {test_username} -- bash -c 'chmod -Rf -t ugo+rwX {tests_path}'"
     else:
-        chmod_cmd = f"chmod -Rf ugo+rwX {tests_path}"
+        chmod_cmd = f"chmod -Rf -t ugo+rwX {tests_path}"
 
     subprocess.run(chmod_cmd, shell=True)
 


### PR DESCRIPTION
During test setup, instructor files are copied to a worker directory. Any directories in the instructor files have the sticky bit set to prevent them from being deleted by worker users running student submissions.

However, if scripts copy directories from within instructor files to another location, the permissions (including the sticky bit) will be copied as well. Test cleanup is performed by a different user, and the presence of the sticky bit prevents deletion of such directories.

This PR explicitly unsets the sticky bit on all directories in the autotest user directory before attempting to delete the contents of the directory, as part of other permissions changes required.

Tested by setting up an assignment which copies a directory from the instructor files to the current working directory. In current master, the folder remains after cleanup is attempted. With this PR, the folder is deleted as expected.

