### PR TITLE
add stack_root to environment

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 - Fix bug that prevented copies of instructor directories from being deleted (#483)
+- Add STACK_ROOT to containers as well as notes in readme (#484)
 
 ## [v2.4.0]
 - Fix bug that prevented test results from being returned when a feedback file could not be found (#458)

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Installing each tester will also install the following additional packages (syst
 - `haskell`
     - ghc 
     - cabal-install 
+    - haskell-stack
     - tasty-stats (cabal package)
     - tasty-discover (cabal package)
     - tasty-quickcheck (cabal package)

--- a/README.md
+++ b/README.md
@@ -260,6 +260,10 @@ ERROR_LOG= # file to write error log informatoin to (default is stderr)
 SETTINGS_JOB_TIMEOUT= # the maximum runtime (in seconds) of a job that updates settings before it is interrupted (default is 60) 
 ```
 
+## Stack configuration
+The Haskell autotester uses [stack](https://docs.haskellstack.org/en/stable/) to install and manage Haskell packages. By default, stack will install to `${HOME}/.stack`, where `${HOME}` is the home directory of the user running the autotester.
+The installation location can be configured by setting a `$STACK_ROOT`, such as the root of the workspace directory.
+
 ## MarkUs configuration options
 
 After installing the autotester and the API, the next step is to [register the MarkUs instance with the autotester](https://github.com/MarkUsProject/Markus/wiki/Installation#autotester-installation-steps).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - WORKSPACE=/home/docker/.autotesting
       - SUPERVISOR_URL=127.0.0.1:9001
       - AUTOTESTER_CONFIG=/app/.dockerfiles/docker-config.yml
+      - STACK_ROOT=/home/docker/.autotesting/.stack
     depends_on:
       - postgres
       - redis


### PR DESCRIPTION
adds `STACK_ROOT` to the environment, which specifies the location for the `.stack` directory for the global stack install. By default this goes to the root of the workspace directory, which I think is sensible for production as well. 

Note: testing requires a rebuild of the autotester environment and running a haskelltest - after that, you should see a `.stack` location in the workspace root