### PR TITLE
create separate sticky bit command

### DIFF
--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -218,7 +218,7 @@ def _run_test_specs(
                         preexec_fn=set_rlimits_before_test,
                         universal_newlines=True,
                         env={**os.environ, **env_vars, **env},
-                        executable='/bin/bash'
+                        executable="/bin/bash",
                     )
                     try:
                         settings_json = json.dumps({**settings, "test_data": test_data})

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -218,6 +218,7 @@ def _run_test_specs(
                         preexec_fn=set_rlimits_before_test,
                         universal_newlines=True,
                         env={**os.environ, **env_vars, **env},
+                        executable='/bin/bash'
                     )
                     try:
                         settings_json = json.dumps({**settings, "test_data": test_data})
@@ -254,10 +255,13 @@ def _clear_working_directory(tests_path: str, test_username: str) -> None:
     Run commands that clear the tests_path working directory
     """
     if test_username != getpass.getuser():
-        chmod_cmd = f"sudo -u {test_username} -- bash -c 'chmod -Rf -t ugo+rwX {tests_path}'"
+        sticky_cmd = f"sudo -u {test_username} -- bash -c 'chmod -Rf -t {tests_path}'"
+        chmod_cmd = f"sudo -u {test_username} -- bash -c 'chmod -Rf ugo+rwX {tests_path}'"
     else:
-        chmod_cmd = f"chmod -Rf -t ugo+rwX {tests_path}"
+        sticky_cmd = f"chmod -Rf -t {tests_path}"
+        chmod_cmd = f"chmod -Rf ugo+rwX {tests_path}"
 
+    subprocess.run(sticky_cmd, shell=True)
     subprocess.run(chmod_cmd, shell=True)
 
     # be careful not to remove the tests_path dir itself since we have to


### PR DESCRIPTION
Previously, we discovered an issue with test directories with the sticky bit set. To fix it, we updated the command that changes permissions such that it explicitly unsets the sticky bit on all directories in the autotest worker directory before attempting to delete the contents of the directory, as part of other permissions changes required.

However, this prevents the standard permission changes (`ugo+rwX`) from being applied to files within directories.

This is an issue if, for example, the tests create their own files and directories and do not explicitly set them to be group executable, because anything within those directories will not be deletable by the `autotst` user.

This PR updates the sticky bit change to run as an entirely separate command.

tested against folders copied from instructor files, as well as folders created by the tests themselves, both with and without the sticky bit applied.

Tests need to be written before this PR can be undrafted