### PR TITLE
Set _env_status earlier when updating settings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented here.
 ## [v2.4.1]
 - Fix bug that prevented copies of instructor directories from being deleted (#483)
 - Add STACK_ROOT to containers as well as notes in readme (#484)
+- Ensure _env_status is updated to "setup" earlier when a request to update test settings is made (#499)
 
 ## [v2.4.0]
 - Fix bug that prevented test results from being returned when a feedback file could not be found (#458)

--- a/client/autotest_client/__init__.py
+++ b/client/autotest_client/__init__.py
@@ -2,6 +2,7 @@ from flask import Flask, request, jsonify, abort, make_response, send_file
 from werkzeug.exceptions import HTTPException
 import os
 import sys
+import time
 import rq
 import json
 import io
@@ -108,6 +109,11 @@ def _update_settings(settings_id, user):
     if error:
         abort(make_response(jsonify(message=error), 422))
 
+    test_settings["_user"] = user
+    test_settings["_last_access"] = int(time.time())
+    test_settings["_env_status"] = "setup"
+    REDIS_CONNECTION.hset("autotest:settings", key=settings_id, value=json.dumps(test_settings))
+
     queue = rq.Queue("settings", connection=REDIS_CONNECTION)
     data = {"user": user, "settings_id": settings_id, "test_settings": test_settings, "file_url": file_url}
     queue.enqueue_call(
@@ -198,7 +204,8 @@ def settings(settings_id, **_kw):
 @authorize
 def create_settings(user):
     settings_id = REDIS_CONNECTION.incr("autotest:settings_id")
-    REDIS_CONNECTION.hset("autotest:settings", key=settings_id, value=json.dumps({"_user": user}))
+    REDIS_CONNECTION.hset("autotest:settings", key=settings_id,
+                          value=json.dumps({"_user": user, "_env_status": "setup"}))
     _update_settings(settings_id, user)
     return {"settings_id": settings_id}
 

--- a/client/autotest_client/__init__.py
+++ b/client/autotest_client/__init__.py
@@ -204,8 +204,9 @@ def settings(settings_id, **_kw):
 @authorize
 def create_settings(user):
     settings_id = REDIS_CONNECTION.incr("autotest:settings_id")
-    REDIS_CONNECTION.hset("autotest:settings", key=settings_id,
-                          value=json.dumps({"_user": user, "_env_status": "setup"}))
+    REDIS_CONNECTION.hset(
+        "autotest:settings", key=settings_id, value=json.dumps({"_user": user, "_env_status": "setup"})
+    )
     _update_settings(settings_id, user)
     return {"settings_id": settings_id}
 

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -366,11 +366,6 @@ def ignore_missing_dir_error(
 
 
 def update_test_settings(user, settings_id, test_settings, file_url):
-    test_settings["_user"] = user
-    test_settings["_last_access"] = int(time.time())
-    test_settings["_env_status"] = "setup"
-    redis_connection().hset("autotest:settings", key=settings_id, value=json.dumps(test_settings))
-
     try:
         settings_dir = os.path.join(TEST_SCRIPT_DIR, str(settings_id))
 


### PR DESCRIPTION
After receiving a request to create/update test settings, the autotester uses the `_env_status` key as a lock to prevent tests from being run while the environment is still being set up. (See #468)

However, because `_env_status` was being set in the server method as part of a job run, there is time between when the create/update settings request is received and the job is executed where new tests could still be run.

In the case of creating a new set of test settings, this could result in a `KeyError: _files` in the `run_tests` server method.

I've changed this so the client is responsible for setting `_env_status`, which should prevent test runs from being executed after the initial settings request is processed, regardless of when the job that sets up the test environment is created.