### PR TITLE
Sticky bit unit test

### DIFF
--- a/server/autotest_server/tests/test_autotest_server.py
+++ b/server/autotest_server/tests/test_autotest_server.py
@@ -1,3 +1,4 @@
+import subprocess
 from pwd import getpwnam
 
 import pytest
@@ -36,9 +37,12 @@ def test_sticky():
     path = f'{autotest_worker_working_dir}/test_sticky'
 
     if not os.path.exists(path):
-        os.system(f"sudo -u {autotest_worker} mkdir {path}")
-        os.system(f"sudo -u {autotest_worker} chmod 000 {path}")
-        os.system(f"sudo -u {autotest_worker} chmod +t {path}")
+        mkdir_cmd = f"sudo -u {autotest_worker} mkdir {path}"
+        chmod_cmd = f"sudo -u {autotest_worker} chmod 000 {path}"
+        chmod_sticky_cmd = f"sudo -u {autotest_worker} chmod +t {path}"
+        subprocess.run(mkdir_cmd, shell=True)
+        subprocess.run(chmod_cmd, shell=True)
+        subprocess.run(chmod_sticky_cmd, shell=True)
 
     autotest_server._clear_working_directory(autotest_worker_working_dir, autotest_worker)
 

--- a/server/autotest_server/tests/test_autotest_server.py
+++ b/server/autotest_server/tests/test_autotest_server.py
@@ -1,5 +1,4 @@
 import subprocess
-from pwd import getpwnam
 
 import pytest
 import fakeredis
@@ -48,4 +47,4 @@ def test_sticky():
 
     autotest_server._clear_working_directory(autotest_worker_working_dir, autotest_worker)
 
-    assert os.path.exists(path) == False
+    assert os.path.exists(path) is False

--- a/server/autotest_server/tests/test_autotest_server.py
+++ b/server/autotest_server/tests/test_autotest_server.py
@@ -42,7 +42,7 @@ def test_sticky():
 
     autotest_server._clear_working_directory(autotest_worker_working_dir, autotest_worker)
 
-    assert not os.path.exists(path) == True
+    assert os.path.exists(path) == False
 
 
 

--- a/server/autotest_server/tests/test_autotest_server.py
+++ b/server/autotest_server/tests/test_autotest_server.py
@@ -1,3 +1,5 @@
+from pwd import getpwnam
+
 import pytest
 import fakeredis
 import rq
@@ -27,10 +29,21 @@ def fake_redis_db(monkeypatch, fake_job):
 def test_redis_connection(fake_redis_conn):
     assert autotest_server.redis_connection() == fake_redis_conn
 
-def is_sticky(path):
-    return os.stat(path).st_mode & 0o1000 == 0o1000
-def test_donny():
-    #create folder, stickyFolder, in same dir. You can do chmod +t stickyFolder or the opposite with -t
-    var1 = is_sticky('stickyFolder')
-    print(f'Is this a sticky bit folder? : {var1}')
+def test_sticky():
+    workers = autotest_server.config["workers"]
+    autotest_worker = workers[0]["user"]
+    autotest_worker_working_dir = f'/home/docker/.autotesting/workers/{autotest_worker}'
+    path = f'{autotest_worker_working_dir}/test_sticky'
+
+    if not os.path.exists(path):
+        os.system(f"sudo -u {autotest_worker} mkdir {path}")
+        os.system(f"sudo -u {autotest_worker} chmod 000 {path}")
+        os.system(f"sudo -u {autotest_worker} chmod +t {path}")
+
+    autotest_server._clear_working_directory(autotest_worker_working_dir, autotest_worker)
+
+    assert not os.path.exists(path) == True
+
+
+
 

--- a/server/autotest_server/tests/test_autotest_server.py
+++ b/server/autotest_server/tests/test_autotest_server.py
@@ -2,7 +2,7 @@ import pytest
 import fakeredis
 import rq
 import autotest_server
-
+import os
 
 @pytest.fixture
 def fake_redis_conn():
@@ -26,3 +26,11 @@ def fake_redis_db(monkeypatch, fake_job):
 
 def test_redis_connection(fake_redis_conn):
     assert autotest_server.redis_connection() == fake_redis_conn
+
+def is_sticky(path):
+    return os.stat(path).st_mode & 0o1000 == 0o1000
+def test_donny():
+    #create folder, stickyFolder, in same dir. You can do chmod +t stickyFolder or the opposite with -t
+    var1 = is_sticky('stickyFolder')
+    print(f'Is this a sticky bit folder? : {var1}')
+

--- a/server/autotest_server/tests/test_autotest_server.py
+++ b/server/autotest_server/tests/test_autotest_server.py
@@ -7,6 +7,7 @@ import rq
 import autotest_server
 import os
 
+
 @pytest.fixture
 def fake_redis_conn():
     yield fakeredis.FakeStrictRedis()
@@ -30,11 +31,12 @@ def fake_redis_db(monkeypatch, fake_job):
 def test_redis_connection(fake_redis_conn):
     assert autotest_server.redis_connection() == fake_redis_conn
 
+
 def test_sticky():
     workers = autotest_server.config["workers"]
     autotest_worker = workers[0]["user"]
-    autotest_worker_working_dir = f'/home/docker/.autotesting/workers/{autotest_worker}'
-    path = f'{autotest_worker_working_dir}/test_sticky'
+    autotest_worker_working_dir = f"/home/docker/.autotesting/workers/{autotest_worker}"
+    path = f"{autotest_worker_working_dir}/test_sticky"
 
     if not os.path.exists(path):
         mkdir_cmd = f"sudo -u {autotest_worker} mkdir {path}"
@@ -47,7 +49,3 @@ def test_sticky():
     autotest_server._clear_working_directory(autotest_worker_working_dir, autotest_worker)
 
     assert os.path.exists(path) == False
-
-
-
-


### PR DESCRIPTION
Created unit test with pytest for making sure when there is a folder with a sticky bit set, the autotester can still clean up the autotest worker's work space.