### PR TITLE
add post-install script for haskell

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -22,10 +22,6 @@ jobs:
     env:
       AUTOTESTER_CONFIG: server/autotest_server/tests/fixtures/test_config.yml
     steps:
-      - name: Set stack_root
-            id: step_one
-            run: |
-              echo "STACK_ROOT=/home/docker/.autotesting/.stack" >> "$GITHUB_ENV"
       - uses: actions/checkout@v2
       - name: Setup python
         uses: actions/setup-python@v2
@@ -40,5 +36,7 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install python packages
         run: python -m pip install pytest fakeredis -r ${{ matrix.test-dir }}/requirements.txt
+      - name: Set stack_root
+        run: echo "STACK_ROOT=/home/docker/.autotesting/.stack" >> "$GITHUB_ENV"
       - name: run tests
         run: pytest ${{ matrix.test-dir }}

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   test:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version:
@@ -22,6 +22,10 @@ jobs:
     env:
       AUTOTESTER_CONFIG: server/autotest_server/tests/fixtures/test_config.yml
     steps:
+      - name: Set stack_root
+            id: step_one
+            run: |
+              echo "STACK_ROOT=/home/docker/.autotesting/.stack" >> "$GITHUB_ENV"
       - uses: actions/checkout@v2
       - name: Setup python
         uses: actions/setup-python@v2

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -36,7 +36,5 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install python packages
         run: python -m pip install pytest fakeredis -r ${{ matrix.test-dir }}/requirements.txt
-      - name: Set stack_root
-        run: echo "STACK_ROOT=/home/docker/.autotesting/.stack" >> "$GITHUB_ENV"
       - name: run tests
         run: pytest ${{ matrix.test-dir }}

--- a/server/autotest_server/testers/haskell/haskell_tester.py
+++ b/server/autotest_server/testers/haskell/haskell_tester.py
@@ -7,7 +7,7 @@ from typing import Dict, Type, List, Iterator, Union
 from ..tester import Tester, Test, TestError
 from ..specs import TestSpecs
 
-STACK_OPTIONS = ["--resolver=lts-14.27", "--system-ghc", "--allow-different-user"]
+STACK_OPTIONS = ["--resolver=lts-16.17", "--system-ghc", "--allow-different-user"]
 
 
 class HaskellTest(Test):

--- a/server/autotest_server/testers/haskell/setup.py
+++ b/server/autotest_server/testers/haskell/setup.py
@@ -7,7 +7,7 @@ HASKELL_TEST_DEPS = ["tasty-discover", "tasty-quickcheck"]
 
 
 def create_environment(_settings, _env_dir, default_env_dir):
-    resolver = "lts-14.27"
+    resolver = "lts-16.17"
     cmd = ["stack", "build", "--resolver", resolver, "--system-ghc", *HASKELL_TEST_DEPS]
     subprocess.run(cmd, check=True)
 
@@ -16,7 +16,10 @@ def create_environment(_settings, _env_dir, default_env_dir):
 
 def install():
     subprocess.run(os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.system"), check=True)
-
+    resolver = "lts-16.17"
+    cmd = ["stack", "build", "--resolver", resolver, "--system-ghc", *HASKELL_TEST_DEPS]
+    subprocess.run(cmd, check=True)
+    subprocess.run(os.path.join(os.path.dirname(os.path.realpath(__file__)), "stack_permissions.sh"), check=True, shell=True)
 
 def settings():
     with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), "settings_schema.json")) as f:

--- a/server/autotest_server/testers/haskell/stack_permissions.sh
+++ b/server/autotest_server/testers/haskell/stack_permissions.sh
@@ -1,0 +1,4 @@
+echo "allow-different-user: true" >> $STACK_ROOT/config.yaml
+chmod a+w $STACK_ROOT/stack.sqlite3.pantry-write-lock
+chmod a+w $STACK_ROOT/global-project/.stack-work/stack.sqlite3.pantry-write-lock
+chmod a+w $STACK_ROOT/pantry/pantry.sqlite3.pantry-write-lock

--- a/server/autotest_server/testers/haskell/stack_permissions.sh
+++ b/server/autotest_server/testers/haskell/stack_permissions.sh
@@ -1,4 +1,5 @@
 echo "allow-different-user: true" >> $STACK_ROOT/config.yaml
+echo "recommend-stack-upgrade: false" >> $STACK_ROOT/config.yaml
 chmod a+w $STACK_ROOT/stack.sqlite3.pantry-write-lock
 chmod a+w $STACK_ROOT/global-project/.stack-work/stack.sqlite3.pantry-write-lock
 chmod a+w $STACK_ROOT/pantry/pantry.sqlite3.pantry-write-lock

--- a/server/autotest_server/tests/test_autotest_server.py
+++ b/server/autotest_server/tests/test_autotest_server.py
@@ -48,3 +48,9 @@ def test_sticky():
     autotest_server._clear_working_directory(autotest_worker_working_dir, autotest_worker)
 
     assert os.path.exists(path) is False
+
+def test_stack_permissions():
+    stack_root = os.environ['STACK_ROOT']
+    path = f"{stack_root}/stack.sqlite3.pantry-write-lock"
+    permissions = oct(os.stat(path).st_mode)[-3:]
+    assert permissions[1] == '6'

--- a/server/autotest_server/tests/test_autotest_server.py
+++ b/server/autotest_server/tests/test_autotest_server.py
@@ -48,4 +48,3 @@ def test_sticky():
     autotest_server._clear_working_directory(autotest_worker_working_dir, autotest_worker)
 
     assert os.path.exists(path) is False
-

--- a/server/autotest_server/tests/test_autotest_server.py
+++ b/server/autotest_server/tests/test_autotest_server.py
@@ -49,9 +49,3 @@ def test_sticky():
 
     assert os.path.exists(path) is False
 
-
-def test_stack_permissions():
-    stack_root = os.environ["STACK_ROOT"]
-    path = f"{stack_root}/stack.sqlite3.pantry-write-lock"
-    permissions = oct(os.stat(path).st_mode)[-3:]
-    assert permissions[1] == "6"


### PR DESCRIPTION
Add a post-install script to update permissions on `stack` created files needed for worker users to run stack build/exec. Note that I also updated the resolver used as `16.17` is the lowest resolver compatible with ubuntu 22.04's default `ghc`. I've opened an issue about making the resolver version a setting, and I think we should make a PR to make it a setting before this PR goes into release. 

Note: there was originally a test for this change, but because the tests do not currently install all testers, it failed. We can re-add tests in a later PR where we make tests more extensive. (part of the changes for the test involved updating `test_ci.yml`. I noted that the tests were still running on ubuntu 20.04, so I updated that to 20.04. I've left that change in as it should have been in a previous PR.)