### PR TITLE
attempt to clean local directory before setting up test files

### DIFF
--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -343,6 +343,7 @@ def run_test(settings_id, test_id, files_url, categories, user, test_env_vars):
         redis_connection().hset("autotest:settings", key=settings_id, value=json.dumps(settings))
         test_username, tests_path = tester_user()
         try:
+            _clear_working_directory(tests_path, test_username)
             _setup_files(settings_id, user, files_url, tests_path, test_username)
             cmd = run_test_command(test_username=test_username)
             results = _run_test_specs(cmd, settings, categories, tests_path, test_username, test_id, test_env_vars)

--- a/server/autotest_server/tests/test_autotest_server.py
+++ b/server/autotest_server/tests/test_autotest_server.py
@@ -48,3 +48,20 @@ def test_sticky():
     autotest_server._clear_working_directory(autotest_worker_working_dir, autotest_worker)
 
     assert os.path.exists(path) is False
+
+
+def test_pre_remove():
+    workers = autotest_server.config["workers"]
+    autotest_worker = workers[0]["user"]
+    autotest_worker_working_dir = f"/home/docker/.autotesting/workers/{autotest_worker}"
+    path = f"{autotest_worker_working_dir}/__pycache__"
+
+    if not os.path.exists(path):
+        mkdir_cmd = f"sudo -u {autotest_worker} mkdir {path}"
+        chmod_cmd = f"sudo -u {autotest_worker} chmod 000 {path}"
+        subprocess.run(mkdir_cmd, shell=True)
+        subprocess.run(chmod_cmd, shell=True)
+
+    autotest_server._clear_working_directory(autotest_worker_working_dir, autotest_worker)
+
+    assert os.path.exists(path) is False


### PR DESCRIPTION
Currently in some situations (such as when an autotest worker is unexpectedly killed), files can fail to be cleaned up at the end of a test run. This can result in subsequent test runs reporting an error like `[Errno 1] Operation not permitted: '/home/docker/.autotesting/workers/autotst0/__pycache__'`

However, the files are still cleaned up at the end of the test run, so subsequent test runs do not return this error.

This PR adds an attempt to clear the worker directory before setting up the assignment's files, in case there are leftover files from a previous test run.

Steps to reproduce the behavior locally:

1. In server/docker-onfig.yml comment out lines 7 onwards and restart the server so it only runs one worker (for convenience)
2. `sudo -u autotst0 -- mkdir autotst0/__pycache__`
3. `sudo -u autotst0 -- touch autotst0/__pycache__/test.txt`
4. `sudo -u autotst0 -- chmod a-rx autotst0/__pycache__/ `
5. `sudo -u autotst0 -- chmod u+rx autotst0/__pycache__/ `

I added one test, but note that it is largely redundant with Donny's