### PR TITLE
add tidyverse as a default package for the R tester

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented here.
 
 ## [unreleased]
+- Add tidyverse as a default R tester package (#512)
 
 ## [v2.4.2]
 - Ensure _env_status is updated to "setup" earlier when a request to update test settings is made (#499)

--- a/server/.dockerfiles/Dockerfile
+++ b/server/.dockerfiles/Dockerfile
@@ -25,7 +25,16 @@ RUN apt-get update -y && \
                        postgresql-client \
                        libpq-dev \
                        sudo \
-                       git
+                       git \
+                       libfontconfig1-dev \
+                       libcurl4-openssl-dev \
+                       libfreetype6-dev \
+                       libpng-dev \
+                       libtiff5-dev \
+                       libjpeg-dev \
+                       libharfbuzz-dev \
+                       libfribidi-dev \
+                       r-base
 
 RUN useradd -ms /bin/bash $LOGIN_USER && \
     usermod -aG sudo $LOGIN_USER && \
@@ -44,6 +53,8 @@ RUN python3.11 -m venv /markus_venv && \
     /markus_venv/bin/pip install -r /app/requirements.txt && \
     find /app/autotest_server/testers -name requirements.system -exec {} \; && \
     rm -rf /app/*
+
+RUN echo "TZ=$( cat /etc/timezone )" >> /etc/R/Renviron.site
 
 RUN mkdir -p ${WORKSPACE} && chown ${LOGIN_USER} ${WORKSPACE}
 

--- a/server/autotest_server/testers/r/lib/r_tester_setup.R
+++ b/server/autotest_server/testers/r/lib/r_tester_setup.R
@@ -12,7 +12,7 @@ library(remotes)
 main <- function() {
   # Tester dependencies
   # rjson v0.2.20 is required to support R v3.x
-  deps <- "testthat, rjson (== 0.2.20)"
+  deps <- "testthat, rjson (== 0.2.20), stringi, tidyverse"
 
   # Additional dependencies for test environment from command-line args
   args <- commandArgs(TRUE)
@@ -53,7 +53,12 @@ install_dep <- function(row) {
   } else if (!is.na(version)) {
     install_version(name, version = paste(compare, version, sep =" "))
   } else {
-    install.packages(name)
+    if (name == 'stringi') {
+      install.packages(name, configure.args="--disable-pkg-config")
+    }
+    else {
+      install.packages(name)
+    }
   }
 
   if (!(name %in% installed.packages())) {


### PR DESCRIPTION
Adds tidyverse as a default package for the R tester.

Note that this requires rebuilding the autotesting docker environment. Several packages are added to support tidyverse. Additionally, R is installed on build, rather than in the `install` script.  This is because in the absence of a defined timezone, the tidyverse install attempts to invoke `timedatectl`, which is not runnable by default in docker. After R is installed, the timezone from `/etc/timezone` is added to R's platform-wide `Renviron.site`, which requires root. I did try to pass the timezone as an environment variable to the R install command, but it seems like R ignores that.

