### PR TITLE
haskell tester: make stack resolver a setting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 - Add tidyverse as a default R tester package (#512)
+- haskell tester: make stack resolver a setting (#515)
 
 ## [v2.4.2]
 - Ensure _env_status is updated to "setup" earlier when a request to update test settings is made (#499)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - SUPERVISOR_URL=127.0.0.1:9001
       - AUTOTESTER_CONFIG=/app/.dockerfiles/docker-config.yml
       - STACK_ROOT=/home/docker/.autotesting/.stack
+      - STACK_RESOLVER=lts-16.17
     depends_on:
       - postgres
       - redis

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+import logging
 import os
 import sys
 import shutil
@@ -368,12 +370,11 @@ def ignore_missing_dir_error(
     if err_type == FileNotFoundError:
         return
     raise err_inst
-
+logger = logging.getLogger(__name__)
 
 def update_test_settings(user, settings_id, test_settings, file_url):
     try:
         settings_dir = os.path.join(TEST_SCRIPT_DIR, str(settings_id))
-
         os.makedirs(settings_dir, exist_ok=True)
         os.chmod(TEST_SCRIPT_DIR, 0o755)
 
@@ -396,6 +397,8 @@ def update_test_settings(user, settings_id, test_settings, file_url):
             default_env = os.path.join(TEST_SCRIPT_DIR, DEFAULT_ENV_DIR)
             if not os.path.isdir(default_env):
                 subprocess.run([sys.executable, "-m", "venv", default_env], check=True)
+                requirements_path = os.path.join(os.path.dirname(__file__), '../requirements.txt')
+                subprocess.run([f"{default_env}/bin/pip", 'install', '-r', requirements_path], check=True)
             try:
                 tester_settings["_env"] = tester_install.create_environment(tester_settings, env_dir, default_env)
             except Exception as e:

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -1,6 +1,4 @@
 from __future__ import annotations
-
-import logging
 import os
 import sys
 import shutil
@@ -370,9 +368,6 @@ def ignore_missing_dir_error(
     if err_type == FileNotFoundError:
         return
     raise err_inst
-
-
-logger = logging.getLogger(__name__)
 
 
 def update_test_settings(user, settings_id, test_settings, file_url):

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -378,6 +378,7 @@ logger = logging.getLogger(__name__)
 def update_test_settings(user, settings_id, test_settings, file_url):
     try:
         settings_dir = os.path.join(TEST_SCRIPT_DIR, str(settings_id))
+
         os.makedirs(settings_dir, exist_ok=True)
         os.chmod(TEST_SCRIPT_DIR, 0o755)
 

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -370,7 +370,10 @@ def ignore_missing_dir_error(
     if err_type == FileNotFoundError:
         return
     raise err_inst
+
+
 logger = logging.getLogger(__name__)
+
 
 def update_test_settings(user, settings_id, test_settings, file_url):
     try:
@@ -397,8 +400,8 @@ def update_test_settings(user, settings_id, test_settings, file_url):
             default_env = os.path.join(TEST_SCRIPT_DIR, DEFAULT_ENV_DIR)
             if not os.path.isdir(default_env):
                 subprocess.run([sys.executable, "-m", "venv", default_env], check=True)
-                requirements_path = os.path.join(os.path.dirname(__file__), '../requirements.txt')
-                subprocess.run([f"{default_env}/bin/pip", 'install', '-r', requirements_path], check=True)
+                requirements_path = os.path.join(os.path.dirname(__file__), "../requirements.txt")
+                subprocess.run([f"{default_env}/bin/pip", "install", "-r", requirements_path], check=True)
             try:
                 tester_settings["_env"] = tester_install.create_environment(tester_settings, env_dir, default_env)
             except Exception as e:

--- a/server/autotest_server/settings.yml
+++ b/server/autotest_server/settings.yml
@@ -1,6 +1,7 @@
 workspace: !ENV ${WORKSPACE}
 redis_url: !ENV ${REDIS_URL}
 supervisor_url: !ENV ${SUPERVISOR_URL}
+stack_resolver: !ENV ${STACK_RESOLVER}
 workers:
   - user: !ENV ${USER}
     queues:

--- a/server/autotest_server/testers/haskell/haskell_tester.py
+++ b/server/autotest_server/testers/haskell/haskell_tester.py
@@ -6,8 +6,9 @@ from typing import Dict, Type, List, Iterator, Union
 
 from ..tester import Tester, Test, TestError
 from ..specs import TestSpecs
+from config import config
 
-STACK_OPTIONS = ["--resolver=lts-16.17", "--system-ghc", "--allow-different-user"]
+STACK_OPTIONS = [f"--resolver={config['stack_resolver']}", "--system-ghc", "--allow-different-user"]
 
 
 class HaskellTest(Test):

--- a/server/autotest_server/testers/haskell/setup.py
+++ b/server/autotest_server/testers/haskell/setup.py
@@ -1,13 +1,13 @@
 import os
 import json
 import subprocess
-
+from ...config import config
 
 HASKELL_TEST_DEPS = ["tasty-discover", "tasty-quickcheck"]
 
 
 def create_environment(_settings, _env_dir, default_env_dir):
-    resolver = "lts-16.17"
+    resolver = config["stack_resolver"]
     cmd = ["stack", "build", "--resolver", resolver, "--system-ghc", *HASKELL_TEST_DEPS]
     subprocess.run(cmd, check=True)
 
@@ -16,7 +16,7 @@ def create_environment(_settings, _env_dir, default_env_dir):
 
 def install():
     subprocess.run(os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.system"), check=True)
-    resolver = "lts-16.17"
+    resolver = config["stack_resolver"]
     cmd = ["stack", "build", "--resolver", resolver, "--system-ghc", *HASKELL_TEST_DEPS]
     subprocess.run(cmd, check=True)
     subprocess.run(


### PR DESCRIPTION
Purpose: make stack resolver a setting

Note: requires rebuilding docker environment for new env var `STACK_RESOLVER`

Test:
Ran a haskell test for a submission to see if it was successful:
1) save Automtated Testing settings to see if that is successful
2) run a test for a submission to see if that is successful