### PR TITLE
clear files created in tmp after test runs

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: python -m pip install pytest fakeredis typing-extensions -r ${{ matrix.test-dir }}/requirements.txt
       - name: Create users
         run: |
-          adduser --disabled-login --no-create-home fake_user && usermod -aG fake_user docker
-          adduser --disabled-login --no-create-home fake_user_2 && usermod -aG fake_user_2 docker
+          sudo adduser --disabled-login --no-create-home fake_user && usermod -aG fake_user docker
+          sudo adduser --disabled-login --no-create-home fake_user_2 && usermod -aG fake_user_2 docker
       - name: run tests
         run: pytest ${{ matrix.test-dir }}

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: python -m pip install pytest fakeredis typing-extensions -r ${{ matrix.test-dir }}/requirements.txt
       - name: Create users
         run: |
-          sudo adduser --disabled-login --no-create-home fake_user && usermod -aG fake_user docker
-          sudo adduser --disabled-login --no-create-home fake_user_2 && usermod -aG fake_user_2 docker
+          sudo adduser --disabled-login --no-create-home fake_user
+          sudo adduser --disabled-login --no-create-home fake_user_2
       - name: run tests
         run: pytest ${{ matrix.test-dir }}

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -36,5 +36,9 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install python packages
         run: python -m pip install pytest fakeredis typing-extensions -r ${{ matrix.test-dir }}/requirements.txt
+      - name: Create users
+        run: |
+          adduser --disabled-login --no-create-home fake_user && usermod -aG fake_user docker
+          adduser --disabled-login --no-create-home fake_user_2 && usermod -aG fake_user_2 docker
       - name: run tests
         run: pytest ${{ matrix.test-dir }}

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 - Add tidyverse as a default R tester package (#512)
+- Clean up tmp directory after test runs (#528)
 
 ## [v2.4.3]
 - Omit skipped test cases in Python tester (#522)

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -257,9 +257,13 @@ def _clear_working_directory(tests_path: str, test_username: str) -> None:
     if test_username != getpass.getuser():
         sticky_cmd = f"sudo -u {test_username} -- bash -c 'chmod -Rf -t {tests_path}'"
         chmod_cmd = f"sudo -u {test_username} -- bash -c 'chmod -Rf ugo+rwX {tests_path}'"
+        clean_tmp_cmd = (
+            f"sudo -u {test_username} -- bash -c 'find /tmp -maxdepth 1 -user {test_username} -exec rm " f"-rf {{}} +' "
+        )
     else:
         sticky_cmd = f"chmod -Rf -t {tests_path}"
         chmod_cmd = f"chmod -Rf ugo+rwX {tests_path}"
+        clean_tmp_cmd = f"find /tmp -maxdepth 1 -user {test_username} -exec rm -rf {{}} +"
 
     subprocess.run(sticky_cmd, shell=True)
     subprocess.run(chmod_cmd, shell=True)
@@ -268,6 +272,7 @@ def _clear_working_directory(tests_path: str, test_username: str) -> None:
     # set the group ownership with sudo (and that is only done in ../install.sh)
     clean_cmd = f"rm -rf {tests_path}/.[!.]* {tests_path}/*"
     subprocess.run(clean_cmd, shell=True)
+    subprocess.run(clean_tmp_cmd, shell=True)
 
 
 def _stop_tester_processes(test_username: str) -> None:

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -252,7 +252,8 @@ def _run_test_specs(
 
 def _clear_working_directory(tests_path: str, test_username: str) -> None:
     """
-    Run commands that clear the tests_path working directory
+    Run commands that clear the tests_path working directory, as well
+    as clearing any files or directories owned by test_username in the /tmp directory
     """
     if test_username != getpass.getuser():
         sticky_cmd = f"sudo -u {test_username} -- bash -c 'chmod -Rf -t {tests_path}'"

--- a/server/autotest_server/tests/fixtures/test_config.yml
+++ b/server/autotest_server/tests/fixtures/test_config.yml
@@ -3,7 +3,9 @@ redis_url: fake_url
 supervisor_url: fake_url
 workers:
   - user: fake_user
-    queues:
+    queues: &queues
       - high
       - low
       - batch
+  - user: fake_user_2
+    queues: *queues

--- a/server/autotest_server/tests/test_autotest_server.py
+++ b/server/autotest_server/tests/test_autotest_server.py
@@ -65,3 +65,41 @@ def test_pre_remove():
     autotest_server._clear_working_directory(autotest_worker_working_dir, autotest_worker)
 
     assert os.path.exists(path) is False
+
+
+def test_tmp_remove_file():
+    workers = autotest_server.config["workers"]
+    autotest_worker = workers[0]["user"]
+    autotest_worker_working_dir = f"/home/docker/.autotesting/workers/{autotest_worker}"
+    path = "/tmp/test.txt"
+    touch_cmd = f"sudo -u {autotest_worker} touch {path}"
+    subprocess.run(touch_cmd, shell=True)
+    autotest_server._clear_working_directory(autotest_worker_working_dir, autotest_worker)
+    assert os.path.exists(path) is False
+
+
+def test_tmp_remove_dir():
+    workers = autotest_server.config["workers"]
+    autotest_worker = workers[0]["user"]
+    autotest_worker_working_dir = f"/home/docker/.autotesting/workers/{autotest_worker}"
+    path = "/tmp/folder"
+    mkdir_cmd = f"sudo -u {autotest_worker} mkdir {path}"
+    subprocess.run(mkdir_cmd, shell=True)
+    touch_cmd = f"sudo -u {autotest_worker} touch {path}/test.txt"
+    subprocess.run(touch_cmd, shell=True)
+    autotest_server._clear_working_directory(autotest_worker_working_dir, autotest_worker)
+    assert os.path.exists(path) is False
+
+
+def test_tmp_remove_other_user():
+    workers = autotest_server.config["workers"]
+    autotest_worker_creator = workers[0]["user"]
+    autotest_worker_remover = workers[1]["user"]
+    autotest_worker_working_dir = f"/home/docker/.autotesting/workers/{autotest_worker_remover}"
+    path = "/tmp/folder"
+    mkdir_cmd = f"sudo -u {autotest_worker_creator} mkdir {path}"
+    subprocess.run(mkdir_cmd, shell=True)
+    touch_cmd = f"sudo -u {autotest_worker_creator} touch {path}/test.txt"
+    subprocess.run(touch_cmd, shell=True)
+    autotest_server._clear_working_directory(autotest_worker_working_dir, autotest_worker_remover)
+    assert os.path.exists(path) is True


### PR DESCRIPTION
In some cases, the autotester will create files in `/tmp` during test runs. Currently these are not automatically removed, leading to issues when `/tmp` becomes full. This PR adds a cleanup of the `/tmp` directory during test teardown. All files and directories belonging to the current user will be removed at the end of tests.