### PR TITLE
use rownames to check installed packages and ensure stringi installed…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented here.
 
 ## [unreleased]
+- Ensure R packages are correctly installed (#535)
 
 ## [v2.4.4]
 - Add tidyverse as a default R tester package (#512)

--- a/server/autotest_server/testers/r/lib/r_tester_setup.R
+++ b/server/autotest_server/testers/r/lib/r_tester_setup.R
@@ -39,7 +39,7 @@ install_dep <- function(row) {
     remote_type <- NA_character_
   }
   if (!('stringi' %in% rownames(installed.packages))) {
-  install.packages(name, configure.args="--disable-pkg-config")
+    install.packages(name, configure.args="--disable-pkg-config")
   }
 
   # Check if package is already installed
@@ -59,7 +59,7 @@ install_dep <- function(row) {
     install.packages(name)
   }
 
-  if (!(name %in% installed.packages())) {
+  if (!(name %in% rownames(installed.packages()))) {
     stop("ERROR: Could not install package ", name)
   }
 }

--- a/server/autotest_server/testers/r/lib/r_tester_setup.R
+++ b/server/autotest_server/testers/r/lib/r_tester_setup.R
@@ -38,10 +38,13 @@ install_dep <- function(row) {
   } else {
     remote_type <- NA_character_
   }
+  if (!('stringi' %in% rownames(installed.packages))) {
+  install.packages(name, configure.args="--disable-pkg-config")
+  }
 
   # Check if package is already installed
   # TODO: make this work for remote packages (with '/' in the name)
-  if (name %in% installed.packages() &&
+  if (name %in% rownames(installed.packages()) &&
       (is.na(version) || version_satisfies_criterion(name, compare, version))) {
       print(paste("Skipping '", name, "': package already installed", sep=""))
       return()
@@ -53,12 +56,7 @@ install_dep <- function(row) {
   } else if (!is.na(version)) {
     install_version(name, version = paste(compare, version, sep =" "))
   } else {
-    if (name == 'stringi') {
-      install.packages(name, configure.args="--disable-pkg-config")
-    }
-    else {
-      install.packages(name)
-    }
+    install.packages(name)
   }
 
   if (!(name %in% installed.packages())) {


### PR DESCRIPTION
This PR attempts to fix two issues related to R testing:

1) recently we received a report of the `testthat` library not being installed correctly. Upon examination, it appears that checking `installed.packages()` is sufficient, because `installed.packages()` also lists dependencies in some rows, which can include `testthat`. So the R tester skipped installation. This is fixed by checking `rownames(installed.packages())`, which returns only the names of installed packages.

2) In production, the libraries were not installing in the expected order. This sometimes resulted in the program attempting to install `tidyverse` before `stringi`. But since `stringi` is a `tidyverse` dependency, and `stringi` requires specific configuration on ubuntu 22.04, this breaks the install process. Thus we ensure that stringi is always the first package installed. 