### PR TITLE
Make PyTA version a setting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented here.
 - Add tidyverse as a default R tester package (#512)
 - For the Haskell tester, make stack resolver a test setting (#526)
 - Clean up tmp directory after test runs (#528)
+- Make PyTA version a setting (#536)
 
 ## [v2.4.3]
 - Omit skipped test cases in Python tester (#522)

--- a/server/autotest_server/testers/pyta/requirements.txt
+++ b/server/autotest_server/testers/pyta/requirements.txt
@@ -1,3 +1,1 @@
-python-ta==1.4.2;python_version<"3.8"
-python-ta==2.7.0; python_version>="3.8"
 isort<5;python_version<"3.8"

--- a/server/autotest_server/testers/pyta/settings_schema.json
+++ b/server/autotest_server/testers/pyta/settings_schema.json
@@ -25,6 +25,11 @@
         "pip_requirements": {
           "title": "Package requirements",
           "type": "string"
+        },
+        "pyta_version": {
+          "title": "PyTA version",
+          "type": "string",
+          "default": null
         }
       }
     },

--- a/server/autotest_server/testers/pyta/setup.py
+++ b/server/autotest_server/testers/pyta/setup.py
@@ -3,15 +3,21 @@ import shutil
 import json
 import subprocess
 
+PYTA_VERSION_PREFIX = "python-ta=="
+PYTA_VERSION = "2.7.0"
+
 
 def create_environment(settings_, env_dir, _default_env_dir):
     env_data = settings_.get("env_data", {})
     python_version = env_data.get("python_version", "3")
-    pip_requirements = ["wheel"] + env_data.get("pip_requirements", "").split()
+    env_properties = ["wheel"] + env_data.get("pip_requirements", "").split()
+    pyta_version = env_data.get("pyta_version", PYTA_VERSION)
+    pyta_version = PYTA_VERSION_PREFIX + pyta_version
+    env_properties.append(pyta_version)
     requirements = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.txt")
     pip = os.path.join(env_dir, "bin", "pip")
     subprocess.run([f"python{python_version}", "-m", "venv", "--clear", env_dir], check=True)
-    subprocess.run([pip, "install", "-r", requirements, *pip_requirements], check=True)
+    subprocess.run([pip, "install", "-r", requirements, *env_properties], check=True)
     return {"PYTHON": os.path.join(env_dir, "bin", "python3")}
 
 
@@ -22,6 +28,8 @@ def settings():
     python_versions = settings_["properties"]["env_data"]["properties"]["python_version"]
     python_versions["enum"] = py_versions
     python_versions["default"] = py_versions[-1]
+    pyta_version = settings_["properties"]["env_data"]["properties"]["pyta_version"]
+    pyta_version["default"] = PYTA_VERSION
     return settings_
 
 


### PR DESCRIPTION
**Proposed Changes:**

Make PyTA version a setting in the test settings for instructors to configure.

**Note:**
Python version 3.8 will be reaching end of like Oct 2024 (https://devguide.python.org/versions/). I have removed the following from the requirements.txt file and set it as a default for 2.7.0 in the setup.py file:
```
python-ta==1.4.2;python_version<"3.8"
python-ta==2.7.0; python_version>="3.8"
```

**Testing procedure:**

1. Rebuild schema: we have a new field "PyTA version"
2. Save the PyTA Automated Test settings
3. Run a submission for a PyTA assignment to see if it is successful


