### PR TITLE
R tester improvements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented here.
 - Make PyTA version a setting (#536)
 - Add `libxml2-dev` to server `Dockerfile`, required by R `tidyverse` library (#539)
 - Display stderr contents if R packages fail to install (#539)
+- Do not display `testthat` failure messages when test case passes (#539)
 
 ## [v2.4.4]
 - Add tidyverse as a default R tester package (#512)

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,12 +3,13 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 - Ensure R packages are correctly installed (#535)
+- Make PyTA version a setting (#536)
+- Add `libxml2-dev` to server `Dockerfile`, required by R `tidyverse` library (#539)
 
 ## [v2.4.4]
 - Add tidyverse as a default R tester package (#512)
 - For the Haskell tester, make stack resolver a test setting (#526)
 - Clean up tmp directory after test runs (#528)
-- Make PyTA version a setting (#536)
 
 ## [v2.4.3]
 - Omit skipped test cases in Python tester (#522)

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented here.
 - Ensure R packages are correctly installed (#535)
 - Make PyTA version a setting (#536)
 - Add `libxml2-dev` to server `Dockerfile`, required by R `tidyverse` library (#539)
+- Display stderr contents if R packages fail to install (#539)
 
 ## [v2.4.4]
 - Add tidyverse as a default R tester package (#512)

--- a/server/.dockerfiles/Dockerfile
+++ b/server/.dockerfiles/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update -y && \
                        libjpeg-dev \
                        libharfbuzz-dev \
                        libfribidi-dev \
+                       libxml2-dev \
                        r-base
 
 RUN useradd -ms /bin/bash $LOGIN_USER && \

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -405,7 +405,10 @@ def update_test_settings(user, settings_id, test_settings, file_url):
             try:
                 tester_settings["_env"] = tester_install.create_environment(tester_settings, env_dir, default_env)
             except Exception as e:
-                raise Exception(f"create tester environment failed:\n{e}") from e
+                error_message = f"create tester environment failed:\n{e}"
+                if e.stderr:
+                    error_message += f"\nDetails (captured stderr):\n{e.stderr}"
+                raise Exception(error_message) from e
             test_settings["testers"][i] = tester_settings
         test_settings["_files"] = files_dir
         test_settings.pop("_error", None)

--- a/server/autotest_server/testers/r/r_tester.py
+++ b/server/autotest_server/testers/r/r_tester.py
@@ -34,7 +34,10 @@ class RTest(Test):
         successes = 0
         error = False
         for result in self.result:
-            messages.append(result["message"])
+            # Only add message if not a success, as testthat reports failure messages only
+            if result["type"] != "expectation_success":
+                messages.append(result["message"])
+
             if result["type"] == "expectation_success":
                 self.points_total += 1
                 successes += 1

--- a/server/autotest_server/testers/r/setup.py
+++ b/server/autotest_server/testers/r/setup.py
@@ -10,7 +10,13 @@ def create_environment(settings_, env_dir, default_env_dir):
     env = {"R_LIBS_SITE": env_dir, "R_LIBS_USER": env_dir}
 
     r_tester_setup = os.path.join(os.path.dirname(os.path.realpath(__file__)), "lib", "r_tester_setup.R")
-    subprocess.run(["Rscript", r_tester_setup, req_string], env={**os.environ, **env}, check=True)
+    subprocess.run(
+        ["Rscript", r_tester_setup, req_string],
+        env={**os.environ, **env},
+        check=True,
+        text=True,
+        capture_output=True,
+    )
 
     return {**env, "PYTHON": os.path.join(default_env_dir, "bin", "python3")}
 


### PR DESCRIPTION
Based on some instructor and TA feedback, I've made two updates to the R tester:

1. Display R package installation stderr if the installation fails. _Note_: this change generalizes to all testers whose `create_environment` setup function raises an error, but only when there is information printed to stderr.
2. Do not display the testthat result `message` field if the test passes. This field is always an error message, even when the test passes, and so should only be displayed on a test failure/error.

During the testing process, I found that tidyverse needed another package, `libxml2-dev`, to be installed, and so I added it to the server Dockerfile.