### PR TITLE
Ensure all Haskell test cases still run within same file when there are failed test cases

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 All notable changes to this project will be documented here.
 
+## [unreleased]
+- Ensure all Haskell test cases still run within same file when there are failed test cases (#543)
+
 ## [v2.5.0]
 - Ensure R packages are correctly installed (#535)
 - Make PyTA version a setting (#536)

--- a/server/autotest_server/testers/haskell/haskell_tester.py
+++ b/server/autotest_server/testers/haskell/haskell_tester.py
@@ -120,9 +120,15 @@ class HaskellTester(Tester):
                 subprocess.run(cmd, stdout=subprocess.DEVNULL, universal_newlines=True, check=True)
                 with tempfile.NamedTemporaryFile(mode="w+", dir=this_dir) as sf:
                     cmd = ["stack", "runghc", *STACK_OPTIONS, "--", f"-i={haskell_lib}", f.name, f"--stats={sf.name}"]
-                    subprocess.run(
-                        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, universal_newlines=True, check=True
-                    )
+                    try:
+                        subprocess.run(
+                            cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, universal_newlines=True, check=True
+                        )
+                    except subprocess.CalledProcessError as e:
+                        if e.returncode == 1:
+                            pass
+                        else:
+                            raise Exception(e)
                     results[test_file] = self._parse_test_results(csv.reader(sf))
         return results
 


### PR DESCRIPTION
**Description:**
When running Haskell tests within a file, and there is at least 1 failed tests, all tests fail in the file even though some of them or passing. The issue is If any test case fails, the **stack runghc** ... command will have an exit status of 1, not 0. This will cause the subprocess.run call to raise an error, because of the check=True argument.

**Solution:**
A try-except block was used around the subprocess.run call. If the return code is 1 we won't raise an error but will still raise it for other errors.

**Testing**
Currently markus-autotesting does not have a framework to do unit-testing for Haskell, and due to time, I did not write unit tests for this. 

However, to do a manual test, I used a Haskell test file that has 1 passing and 1 failing test case where I named the file Test.hs, with the following contents (note: ".hs" extension file is not supported on GitHub, so I am displaying the contents here.):

```
module Test where
import Test.QuickCheck

prop_true :: () -> Bool
prop_true _ = True

prop_false :: () -> Bool
prop_false _ = False
```
It should show 1 passing and 1 failing test in the results after running a test.



