### PR TITLE
show output of compilation failures for haskell

### DIFF
--- a/server/autotest_server/testers/haskell/haskell_tester.py
+++ b/server/autotest_server/testers/haskell/haskell_tester.py
@@ -129,7 +129,13 @@ class HaskellTester(Tester):
                             pass
                         else:
                             raise Exception(e)
-                    results[test_file] = self._parse_test_results(csv.reader(sf))
+                    r = self._parse_test_results(csv.reader(sf))
+                    if r:
+                        results[test_file] = r
+                    else:
+                        subprocess.run(
+                            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, check=True
+                        )
         return results
 
     @Tester.run_decorator


### PR DESCRIPTION
This change was suggested by Lisa Zhang. Currently, if student submissions fail to compile, the MarkUs UI simply displays an 'error all' message. This change causes the tests to fail and the compilation error to be displayed in the 'all tests' message (see screenshot). She suggested it would be helpful to students to see simple errors they can fix.

This pull request is marked draft for review and possible discussion.

<img width="1393" alt="image" src="https://github.com/user-attachments/assets/e5d8d676-630e-4ff0-ba6b-b32baf4c65e7">
