### PR TITLE
Haskell Tests - allow displaying of compilation errors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 All notable changes to this project will be documented here.
 
+## [unreleased]
+- Haskell Tests - allow displaying of compilation errors (#554)
+
 ## [v2.5.1]
 - Ensure all Haskell test cases still run within same file when there are failed test cases (#543)
 

--- a/server/autotest_server/testers/haskell/haskell_tester.py
+++ b/server/autotest_server/testers/haskell/haskell_tester.py
@@ -120,16 +120,14 @@ class HaskellTester(Tester):
                 subprocess.run(cmd, stdout=subprocess.DEVNULL, universal_newlines=True, check=True)
                 with tempfile.NamedTemporaryFile(mode="w+", dir=this_dir) as sf:
                     cmd = ["stack", "runghc", *STACK_OPTIONS, "--", f"-i={haskell_lib}", f.name, f"--stats={sf.name}"]
-                    try:
-                        subprocess.run(
-                            cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, universal_newlines=True, check=True
-                        )
-                    except subprocess.CalledProcessError as e:
-                        if e.returncode == 1:
-                            pass
-                        else:
-                            raise Exception(e)
-                    results[test_file] = self._parse_test_results(csv.reader(sf))
+                    out = subprocess.run(
+                        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, universal_newlines=True, check=False
+                    )
+                    r = self._parse_test_results(csv.reader(sf))
+                    if r:
+                        results[test_file] = r
+                    else:
+                        raise Exception(out.stderr)
         return results
 
     @Tester.run_decorator


### PR DESCRIPTION
**Description:**
This Pull Request allows Haskel Tests to display compilation errors. 

**Testing Steps:**
1. Ensure test file imports student's submission file
2. Add a syntax error to the student's file 
3. Collect and run tests
4. The test results will output the compilation error