### PR TITLE
Add index api for monitoring if Gunicorn is down

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented here.
 
 ## [unreleased]
-- Add index api for monitoring if Gunicorn is down (#555)
+- Add status api for monitoring if Gunicorn is down (#555)
 
 ## [v2.5.1]
 - Ensure all Haskell test cases still run within same file when there are failed test cases (#543)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 All notable changes to this project will be documented here.
 
+## [unreleased]
+- Add index api for monitoring if Gunicorn is down (#555)
+
 ## [v2.5.1]
 - Ensure all Haskell test cases still run within same file when there are failed test cases (#543)
 

--- a/client/autotest_client/__init__.py
+++ b/client/autotest_client/__init__.py
@@ -319,3 +319,8 @@ def cancel_tests(settings_id, **_kw):
     for id_, job in zip(test_ids, _get_jobs(test_ids, settings_id)):
         result[id_] = job if job is None else job.cancel()
     return jsonify(success=True)
+
+
+@app.route("/index", methods=["GET"])
+def index():
+    return jsonify(success=True)

--- a/client/autotest_client/__init__.py
+++ b/client/autotest_client/__init__.py
@@ -321,6 +321,6 @@ def cancel_tests(settings_id, **_kw):
     return jsonify(success=True)
 
 
-@app.route("/index", methods=["GET"])
-def index():
+@app.route("/status", methods=["GET"])
+def status():
     return jsonify(success=True)

--- a/client/autotest_client/tests/test_flask_app.py
+++ b/client/autotest_client/tests/test_flask_app.py
@@ -38,3 +38,13 @@ class TestRegister:
 
     def test_credentials_set(self, response, fake_redis_conn, credentials):
         assert json.loads(fake_redis_conn.hget("autotest:user_credentials", response.json["api_key"])) == credentials
+
+
+class TestIndex:
+
+    @pytest.fixture
+    def response(self, client):
+        return client.get("/index")
+
+    def test_index(self, response):
+        assert response.status_code == 200

--- a/client/autotest_client/tests/test_flask_app.py
+++ b/client/autotest_client/tests/test_flask_app.py
@@ -40,11 +40,14 @@ class TestRegister:
         assert json.loads(fake_redis_conn.hget("autotest:user_credentials", response.json["api_key"])) == credentials
 
 
-class TestIndex:
+class TestStatus:
 
     @pytest.fixture
     def response(self, client):
-        return client.get("/index")
+        return client.get("/status")
 
-    def test_index(self, response):
+    def test_status_code(self, response):
         assert response.status_code == 200
+
+    def test_success(self, response):
+        assert response.json["success"] is True


### PR DESCRIPTION
Description:

We want to have notification when Gunicorn is down/hanging for autotesters. Created an API route, `/index`, that will be called continually to see if there is a HTTP Status 200 response.