### PR TITLE
Update python tester to allow a requirements file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented here.
 
 ## [unreleased]
-- Update python tester to allow a requirements file (#580)
+- Update python, pyta and jupyter testers to allow a requirements file (#580)
 
 ## [v2.6.0]
 - Update python versions in docker file (#568)

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented here.
 
 ## [unreleased]
+- Update python tester to allow a requirements file (#580)
 
 ## [v2.6.0]
 - Update python versions in docker file (#568)

--- a/server/autotest_server/testers/jupyter/settings_schema.json
+++ b/server/autotest_server/testers/jupyter/settings_schema.json
@@ -25,6 +25,10 @@
         "pip_requirements": {
           "title": "Package requirements",
           "type": "string"
+        },
+        "pip_requirements_file": {
+          "title": "Package requirements file",
+          "type": "string"
         }
       }
     },

--- a/server/autotest_server/testers/jupyter/setup.py
+++ b/server/autotest_server/testers/jupyter/setup.py
@@ -11,7 +11,11 @@ def create_environment(settings_, env_dir, _default_env_dir):
     requirements = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.txt")
     pip = os.path.join(env_dir, "bin", "pip")
     subprocess.run([f"python{python_version}", "-m", "venv", "--clear", env_dir], check=True)
-    subprocess.run([pip, "install", "-r", requirements, *pip_requirements], check=True)
+    pip_install_command = [pip, "install", "-r", requirements, *pip_requirements]
+    if env_data.get("pip_requirements_file"):
+        pip_install_command.append("-r")
+        pip_install_command.append(os.path.join(env_dir, "../", "files", env_data.get("pip_requirements_file")))
+    subprocess.run(pip_install_command, check=True)
     return {"PYTHON": os.path.join(env_dir, "bin", "python3")}
 
 

--- a/server/autotest_server/testers/py/settings_schema.json
+++ b/server/autotest_server/testers/py/settings_schema.json
@@ -25,6 +25,10 @@
         "pip_requirements": {
           "title": "Package requirements",
           "type": "string"
+        },
+        "pip_requirements_file": {
+          "title": "Package requirements file",
+          "type": "string"
         }
       }
     },

--- a/server/autotest_server/testers/py/setup.py
+++ b/server/autotest_server/testers/py/setup.py
@@ -11,10 +11,12 @@ def create_environment(settings_, env_dir, _default_env_dir):
     requirements = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.txt")
     pip = os.path.join(env_dir, "bin", "pip")
     subprocess.run([f"python{python_version}", "-m", "venv", "--clear", env_dir], check=True)
-    subprocess.run([pip, "install", "-r", requirements, *pip_requirements], check=True)
+    pip_install_command = [pip, "install", "-r", requirements, *pip_requirements]
     if env_data.get("pip_requirements_file"):
-        pip_requirements_file = os.path.join(env_dir, "../", "files", env_data.get("pip_requirements_file"))
-        subprocess.run([pip, "install", "-r", pip_requirements_file], check=True)
+        pip_install_command.append("-r")
+        pip_install_command.append(os.path.join(env_dir, "../", "files",
+                                   env_data.get("pip_requirements_file")))
+    subprocess.run(pip_install_command, check=True)
     return {"PYTHON": os.path.join(env_dir, "bin", "python3")}
 
 

--- a/server/autotest_server/testers/py/setup.py
+++ b/server/autotest_server/testers/py/setup.py
@@ -14,8 +14,7 @@ def create_environment(settings_, env_dir, _default_env_dir):
     pip_install_command = [pip, "install", "-r", requirements, *pip_requirements]
     if env_data.get("pip_requirements_file"):
         pip_install_command.append("-r")
-        pip_install_command.append(os.path.join(env_dir, "../", "files",
-                                   env_data.get("pip_requirements_file")))
+        pip_install_command.append(os.path.join(env_dir, "../", "files", env_data.get("pip_requirements_file")))
     subprocess.run(pip_install_command, check=True)
     return {"PYTHON": os.path.join(env_dir, "bin", "python3")}
 

--- a/server/autotest_server/testers/py/setup.py
+++ b/server/autotest_server/testers/py/setup.py
@@ -12,6 +12,9 @@ def create_environment(settings_, env_dir, _default_env_dir):
     pip = os.path.join(env_dir, "bin", "pip")
     subprocess.run([f"python{python_version}", "-m", "venv", "--clear", env_dir], check=True)
     subprocess.run([pip, "install", "-r", requirements, *pip_requirements], check=True)
+    if env_data.get("pip_requirements_file"):
+        pip_requirements_file = os.path.join(env_dir, "../", "files", env_data.get("pip_requirements_file"))
+        subprocess.run([pip, "install", "-r", pip_requirements_file], check=True)
     return {"PYTHON": os.path.join(env_dir, "bin", "python3")}
 
 

--- a/server/autotest_server/testers/pyta/settings_schema.json
+++ b/server/autotest_server/testers/pyta/settings_schema.json
@@ -26,6 +26,10 @@
           "title": "Package requirements",
           "type": "string"
         },
+        "pip_requirements_file": {
+          "title": "Package requirements file",
+          "type": "string"
+        },
         "pyta_version": {
           "title": "PyTA version",
           "type": "string",

--- a/server/autotest_server/testers/pyta/setup.py
+++ b/server/autotest_server/testers/pyta/setup.py
@@ -17,7 +17,11 @@ def create_environment(settings_, env_dir, _default_env_dir):
     requirements = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.txt")
     pip = os.path.join(env_dir, "bin", "pip")
     subprocess.run([f"python{python_version}", "-m", "venv", "--clear", env_dir], check=True)
-    subprocess.run([pip, "install", "-r", requirements, *env_properties], check=True)
+    pip_install_command = [pip, "install", "-r", requirements, *env_properties]
+    if env_data.get("pip_requirements_file"):
+        pip_install_command.append("-r")
+        pip_install_command.append(os.path.join(env_dir, "../", "files", env_data.get("pip_requirements_file")))
+    subprocess.run(pip_install_command, check=True)
     return {"PYTHON": os.path.join(env_dir, "bin", "python3")}
 
 


### PR DESCRIPTION
**Changes**:
- Change the Python autotester settings schema to include an optional field for a requirements file
- The Python autotester setup will find the requirements file from the test files and install those packages

**Testing Procedure**
- Rebuild schema and enter a Python assignment. The Python environment section will have a new field: Package requirements file
- Add a requirements file with NumPy and add a test file which uses NumPy.
- Save the settings and run tests
  - With the correct requirements file name provided, the NumPy test passes
  - With an incorrect requirements file name provided, the tests do not start
  - With no requirements file name provided, the NumPy test fails