### PR TITLE
Update R Tester to allow renv.lock file upload 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented here.
 
 ## [unreleased]
+- Update R tester to allow a renv.lock file (#581)
 
 ## [v2.6.0]
 - Update python versions in docker file (#568)

--- a/compose.yaml
+++ b/compose.yaml
@@ -35,7 +35,7 @@ services:
       - REDIS_URL=redis://redis:6379/
       - FLASK_HOST=0.0.0.0
     ports:
-      - '5000:5000'
+      - '5000:5001'
     depends_on:
       - redis
       - server

--- a/compose.yaml
+++ b/compose.yaml
@@ -35,7 +35,7 @@ services:
       - REDIS_URL=redis://redis:6379/
       - FLASK_HOST=0.0.0.0
     ports:
-      - '5001:5001'
+      - '5000:5000'
     depends_on:
       - redis
       - server

--- a/compose.yaml
+++ b/compose.yaml
@@ -35,7 +35,7 @@ services:
       - REDIS_URL=redis://redis:6379/
       - FLASK_HOST=0.0.0.0
     ports:
-      - '5000:5001'
+      - '5001:5001'
     depends_on:
       - redis
       - server

--- a/server/autotest_server/testers/r/lib/r_renv_setup.R
+++ b/server/autotest_server/testers/r/lib/r_renv_setup.R
@@ -6,32 +6,13 @@ if (!("renv" %in% installed.packages())) {
 }
 library(renv)
 
-# Tester dependencies
-# rjson v0.2.20 is required to support R v3.x
-deps <- c("testthat", "rjson", "stringi", "tidyverse")
-
-# Install the required packages if they are not already installed
-installed_deps <- rownames(installed.packages())
-missing_deps <- deps[!deps %in% installed_deps]
-if (length(missing_deps) > 0) {
-  install.packages(missing_deps)
-}
-# Make sure rjson v0.2.20 is installed
-if (!("rjson" %in% installed.packages()[,"Package"]) || 
-    packageVersion("rjson") != "0.2.20") {
-  install.packages("rjson", version = "0.2.20")
-}
-
 # Set the path for the renv.lock file and the env_dir directory
 lockfile <- commandArgs(trailingOnly = TRUE)[1]
 env_dir <- commandArgs(trailingOnly = TRUE)[2]
 
-# Check if renv.lock file exists
 if (!file.exists(lockfile)) {
   stop("renv.lock file not found: ", lockfile)
 }
 
 # Initialize the renv environment and restore dependencies from the lockfile
-renv::restore(lockfile = lockfile, lib = env_dir)
-
-print("R environment setup complete.\n")
+renv::restore(lockfile = lockfile, library = env_dir)

--- a/server/autotest_server/testers/r/lib/r_renv_setup.R
+++ b/server/autotest_server/testers/r/lib/r_renv_setup.R
@@ -1,0 +1,37 @@
+# Script to install dependencies for R tester environment using a renv.lock file. 
+
+# Install renv if not already installed
+if (!("renv" %in% installed.packages())) {
+  install.packages("renv")
+}
+library(renv)
+
+# Tester dependencies
+# rjson v0.2.20 is required to support R v3.x
+deps <- c("testthat", "rjson", "stringi", "tidyverse")
+
+# Install the required packages if they are not already installed
+installed_deps <- rownames(installed.packages())
+missing_deps <- deps[!deps %in% installed_deps]
+if (length(missing_deps) > 0) {
+  install.packages(missing_deps)
+}
+# Make sure rjson v0.2.20 is installed
+if (!("rjson" %in% installed.packages()[,"Package"]) || 
+    packageVersion("rjson") != "0.2.20") {
+  install.packages("rjson", version = "0.2.20")
+}
+
+# Set the path for the renv.lock file and the env_dir directory
+lockfile <- commandArgs(trailingOnly = TRUE)[1]
+env_dir <- commandArgs(trailingOnly = TRUE)[2]
+
+# Check if renv.lock file exists
+if (!file.exists(lockfile)) {
+  stop("renv.lock file not found: ", lockfile)
+}
+
+# Initialize the renv environment and restore dependencies from the lockfile
+renv::restore(lockfile = lockfile, lib = env_dir)
+
+print("R environment setup complete.\n")

--- a/server/autotest_server/testers/r/lib/r_renv_setup.R
+++ b/server/autotest_server/testers/r/lib/r_renv_setup.R
@@ -1,7 +1,7 @@
 # Script to install dependencies for R tester environment using a renv.lock file. 
 
 # Install renv if not already installed
-if (!("renv" %in% installed.packages())) {
+if (!("renv" %in% rownames(installed.packages()))) {
   install.packages("renv")
 }
 library(renv)

--- a/server/autotest_server/testers/r/settings_schema.json
+++ b/server/autotest_server/testers/r/settings_schema.json
@@ -13,11 +13,16 @@
     "env_data": {
       "title": "R environment",
       "type": "object",
+      "required": ["renv.lock"],
       "properties": {
-        "requirements": {
-          "title": "renv lockfile submitted",
-          "type": "boolean", 
+        "renv.lock": {
+          "title": "renv.lock submitted with test files",
+          "type": "boolean",
           "default": false
+        },
+        "requirements": {
+          "title": "Package requirements",
+          "type": "string"
         }
       }
     },

--- a/server/autotest_server/testers/r/settings_schema.json
+++ b/server/autotest_server/testers/r/settings_schema.json
@@ -15,8 +15,9 @@
       "type": "object",
       "properties": {
         "requirements": {
-          "title": "Package requirements",
-          "type": "string"
+          "title": "renv lockfile submitted",
+          "type": "boolean", 
+          "default": false
         }
       }
     },

--- a/server/autotest_server/testers/r/settings_schema.json
+++ b/server/autotest_server/testers/r/settings_schema.json
@@ -13,10 +13,9 @@
     "env_data": {
       "title": "R environment",
       "type": "object",
-      "required": ["renv.lock"],
       "properties": {
         "renv.lock": {
-          "title": "renv.lock submitted with test files",
+          "title": "Use renv to set up environment",
           "type": "boolean",
           "default": false
         },

--- a/server/autotest_server/testers/r/setup.py
+++ b/server/autotest_server/testers/r/setup.py
@@ -2,12 +2,13 @@ import os
 import json
 import subprocess
 
+
 def create_environment(settings_, env_dir, default_env_dir):
     env_data = settings_.get("env_data", {})
     lockfile_submitted = env_data.get("renv.lock", False)
     os.makedirs(env_dir, exist_ok=True)
     env = {"R_LIBS_SITE": env_dir, "R_LIBS_USER": env_dir}
-    
+
     req_string = env_data.get("requirements", "")
     r_tester_setup = os.path.join(os.path.dirname(os.path.realpath(__file__)), "lib", "r_tester_setup.R")
     subprocess.run(
@@ -17,7 +18,7 @@ def create_environment(settings_, env_dir, default_env_dir):
         text=True,
         capture_output=True,
     )
-        
+
     if lockfile_submitted:
         renv_lock_path = os.path.join(env_dir, "../", "files", "renv.lock")
         r_renv_setup = os.path.join(os.path.dirname(os.path.realpath(__file__)), "lib", "r_renv_setup.R")

--- a/server/autotest_server/testers/r/setup.py
+++ b/server/autotest_server/testers/r/setup.py
@@ -2,27 +2,25 @@ import os
 import json
 import subprocess
 
-
 def create_environment(settings_, env_dir, default_env_dir):
     env_data = settings_.get("env_data", {})
-    renv_bool = env_data.get("requirements", False)
+    lockfile_submitted = env_data.get("renv.lock", False)
     os.makedirs(env_dir, exist_ok=True)
     env = {"R_LIBS_SITE": env_dir, "R_LIBS_USER": env_dir}
-
-    #r_tester_setup = os.path.join(os.path.dirname(os.path.realpath(__file__)), "lib", "r_tester_setup.R")
-    # subprocess.run(
-    #     ["Rscript", r_tester_setup, req_string],
-    #     env={**os.environ, **env},
-    #     check=True,
-    #     text=True,
-    #     capture_output=True,
-    # )
     
-    r_renv_setup = os.path.join(os.path.dirname(os.path.realpath(__file__)), "lib", "r_renv_setup.R")
-    
-    if renv_bool:
-        renv_lock_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "renv.lock")
-
+    req_string = env_data.get("requirements", "")
+    r_tester_setup = os.path.join(os.path.dirname(os.path.realpath(__file__)), "lib", "r_tester_setup.R")
+    subprocess.run(
+        ["Rscript", r_tester_setup, req_string],
+        env={**os.environ, **env},
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+        
+    if lockfile_submitted:
+        renv_lock_path = os.path.join(env_dir, "../", "files", "renv.lock")
+        r_renv_setup = os.path.join(os.path.dirname(os.path.realpath(__file__)), "lib", "r_renv_setup.R")
         if os.path.exists(renv_lock_path):
             subprocess.run(
                 ["Rscript", r_renv_setup, renv_lock_path, env_dir],
@@ -31,9 +29,6 @@ def create_environment(settings_, env_dir, default_env_dir):
                 text=True,
                 capture_output=True,
             )
-        else:
-            raise FileNotFoundError(f"renv.lock file not found in {os.path.dirname(os.path.realpath(__file__))}")
-
     return {**env, "PYTHON": os.path.join(default_env_dir, "bin", "python3")}
 
 

--- a/server/autotest_server/testers/r/setup.py
+++ b/server/autotest_server/testers/r/setup.py
@@ -5,18 +5,34 @@ import subprocess
 
 def create_environment(settings_, env_dir, default_env_dir):
     env_data = settings_.get("env_data", {})
-    req_string = env_data.get("requirements", "")
+    renv_bool = env_data.get("requirements", False)
     os.makedirs(env_dir, exist_ok=True)
     env = {"R_LIBS_SITE": env_dir, "R_LIBS_USER": env_dir}
 
-    r_tester_setup = os.path.join(os.path.dirname(os.path.realpath(__file__)), "lib", "r_tester_setup.R")
-    subprocess.run(
-        ["Rscript", r_tester_setup, req_string],
-        env={**os.environ, **env},
-        check=True,
-        text=True,
-        capture_output=True,
-    )
+    #r_tester_setup = os.path.join(os.path.dirname(os.path.realpath(__file__)), "lib", "r_tester_setup.R")
+    # subprocess.run(
+    #     ["Rscript", r_tester_setup, req_string],
+    #     env={**os.environ, **env},
+    #     check=True,
+    #     text=True,
+    #     capture_output=True,
+    # )
+    
+    r_renv_setup = os.path.join(os.path.dirname(os.path.realpath(__file__)), "lib", "r_renv_setup.R")
+    
+    if renv_bool:
+        renv_lock_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "renv.lock")
+
+        if os.path.exists(renv_lock_path):
+            subprocess.run(
+                ["Rscript", r_renv_setup, renv_lock_path, env_dir],
+                env={**os.environ, **env},
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+        else:
+            raise FileNotFoundError(f"renv.lock file not found in {os.path.dirname(os.path.realpath(__file__))}")
 
     return {**env, "PYTHON": os.path.join(default_env_dir, "bin", "python3")}
 


### PR DESCRIPTION
Description:
- Users can provide package dependencies for the R autotester environment by uploading a renv.lock file in addition to manually listing dependencies (existing functionality)

Changes: 
- Updated json schema to include checkbox where users specify if renv.lock file has been uploaded 
- When creating the testing environment, an R script will install the packages in the renv.lock file using renv library if the user chooses

Testing procedure:
- Rebuild schema
- Upload dependencies through renv.lock file and click checkbox, manually list package requirements, or both
- Save the R Automated Test setttings
- Run a submission for R assignment to see if successful

Tests Conducted:
- Uploading one dependency through all use cases: knitr package was 1) entered manually as a package requirement, 2) specified through a renv.lock file, and 3) uploaded through both methods at the same time
- Uploading multiple dependencies through both methods combined:  renv.lock file (knitr package) and manual input (plotly package)