### PR TITLE
Support for tags and overall comments in test group results

### DIFF
--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -68,7 +68,7 @@ def _create_test_group_result(
         "extra_info": extra_info or {},
         "annotations": None,
         "feedback": feedback,
-        "tags": [],
+        "tags": None,
         "overall_comment": None
     }
     for res in all_results:

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -69,7 +69,7 @@ def _create_test_group_result(
         "annotations": None,
         "feedback": feedback,
         "tags": None,
-        "overall_comment": None
+        "overall_comment": None,
     }
     for res in all_results:
         if "annotations" in res:

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -68,10 +68,16 @@ def _create_test_group_result(
         "extra_info": extra_info or {},
         "annotations": None,
         "feedback": feedback,
+        "tags": [],
+        "overall_comment": None
     }
     for res in all_results:
         if "annotations" in res:
             result["annotations"] = res["annotations"]
+        elif "tags" in res:
+            result["tags"] = res["tags"]
+        elif "overall_comment" in res:
+            result["overall_comment"] = res["overall_comment"]
         else:
             result["tests"].append(res)
 


### PR DESCRIPTION
Changes:
- This PR changes the results parser to add tags and overall comments from a test's standard output to its results
- Uses the changes in this PR: [https://github.com/MarkUsProject/Markus/pull/7387](https://github.com/MarkUsProject/Markus/pull/7387)

Testing Procedure:
- I ran a custom autotester with this test script:
`echo '{"annotations": [{"filename": "submission.py", "content": "Message 1!", "line_start": 3, "line_end": 5, "column_start": 1, "column_end": 4}, {"filename": "submission.py", "content": "Message 2!", "line_start": 6, "line_end": 9, "column_start": 1, "column_end": 4}]} {"name": "Custom Test 4", "output": "Perfect!", "marks_earned": 100, "marks_total": 100, "status": "pass", "time": 1} {"overall_comment": "Test 4 Comment 1!"} {"tags": [{"name": "Tag1", "description": "description1"}, {"name": "Tag2", "description": "description2"}]}'`
- The test results contain 2 tags, 1 overall comment, and 2 annotations for the file `submission.py`