### PR TITLE
Improve display of Python package installation errors when creating environment

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented here.
 ## [unreleased]
 - Update python, pyta and jupyter testers to allow a requirements file (#580)
 - Update R tester to allow a renv.lock file (#581)
+- Improve display of Python package installation errors when creating environment (#585)
 
 ## [v2.6.0]
 - Update python versions in docker file (#568)

--- a/server/autotest_server/testers/jupyter/setup.py
+++ b/server/autotest_server/testers/jupyter/setup.py
@@ -10,12 +10,14 @@ def create_environment(settings_, env_dir, _default_env_dir):
     pip_requirements = ["wheel"] + env_data.get("pip_requirements", "").split()
     requirements = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.txt")
     pip = os.path.join(env_dir, "bin", "pip")
-    subprocess.run([f"python{python_version}", "-m", "venv", "--clear", env_dir], check=True)
+    subprocess.run(
+        [f"python{python_version}", "-m", "venv", "--clear", env_dir], check=True, text=True, capture_output=True
+    )
     pip_install_command = [pip, "install", "-r", requirements, *pip_requirements]
     if env_data.get("pip_requirements_file"):
         pip_install_command.append("-r")
         pip_install_command.append(os.path.join(env_dir, "../", "files", env_data.get("pip_requirements_file")))
-    subprocess.run(pip_install_command, check=True)
+    subprocess.run(pip_install_command, check=True, text=True, capture_output=True)
     return {"PYTHON": os.path.join(env_dir, "bin", "python3")}
 
 

--- a/server/autotest_server/testers/py/setup.py
+++ b/server/autotest_server/testers/py/setup.py
@@ -10,12 +10,14 @@ def create_environment(settings_, env_dir, _default_env_dir):
     pip_requirements = ["wheel"] + env_data.get("pip_requirements", "").split()
     requirements = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.txt")
     pip = os.path.join(env_dir, "bin", "pip")
-    subprocess.run([f"python{python_version}", "-m", "venv", "--clear", env_dir], check=True)
+    subprocess.run(
+        [f"python{python_version}", "-m", "venv", "--clear", env_dir], check=True, text=True, capture_output=True
+    )
     pip_install_command = [pip, "install", "-r", requirements, *pip_requirements]
     if env_data.get("pip_requirements_file"):
         pip_install_command.append("-r")
         pip_install_command.append(os.path.join(env_dir, "../", "files", env_data.get("pip_requirements_file")))
-    subprocess.run(pip_install_command, check=True)
+    subprocess.run(pip_install_command, check=True, text=True, capture_output=True)
     return {"PYTHON": os.path.join(env_dir, "bin", "python3")}
 
 

--- a/server/autotest_server/testers/pyta/setup.py
+++ b/server/autotest_server/testers/pyta/setup.py
@@ -16,12 +16,14 @@ def create_environment(settings_, env_dir, _default_env_dir):
     env_properties.append(pyta_version)
     requirements = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.txt")
     pip = os.path.join(env_dir, "bin", "pip")
-    subprocess.run([f"python{python_version}", "-m", "venv", "--clear", env_dir], check=True)
+    subprocess.run(
+        [f"python{python_version}", "-m", "venv", "--clear", env_dir], check=True, text=True, capture_output=True
+    )
     pip_install_command = [pip, "install", "-r", requirements, *env_properties]
     if env_data.get("pip_requirements_file"):
         pip_install_command.append("-r")
         pip_install_command.append(os.path.join(env_dir, "../", "files", env_data.get("pip_requirements_file")))
-    subprocess.run(pip_install_command, check=True)
+    subprocess.run(pip_install_command, check=True, text=True, capture_output=True)
     return {"PYTHON": os.path.join(env_dir, "bin", "python3")}
 
 


### PR DESCRIPTION
Display Python package installation stderr if the installation fails. This is done for testers Py, PyTA and Jypyter.

Screenshot 1: I made a syntax error for the option --clear to have only 1 hyphen when creating the venv

<img width="1156" alt="python venv creation error" src="https://github.com/user-attachments/assets/d4cb685a-9b24-4418-b50a-3c7b028d9590" />


Screenshot 2: in the requirements file, I entered an invalid value of "test=" when installing python packages

<img width="1306" alt="python package install error" src="https://github.com/user-attachments/assets/671db212-5e99-4388-881a-337f6eacbbfd" />


