### PR TITLE
Logging supervisor's child process logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ redis_url: # url of the redis database. default is: redis://127.0.0.1:6379/0
 supervisor_url: # url used by the supervisor process. default is: '127.0.0.1:9001'
                 # This can also be set with the SUPERVISOR_URL environment variable.
 
+worker_log_dir: # an absolute path to a directory containing the worker's stdout and stderr logs.
+
 rlimit_settings: # RLIMIT settings (see details below)
   nproc: # for example, this setting sets the hard and soft limits for the number of processes available to 300
     - 300

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,6 +17,7 @@ services:
       - SUPERVISOR_URL=127.0.0.1:9001
       - AUTOTESTER_CONFIG=/app/.dockerfiles/docker-config.yml
       - STACK_ROOT=/home/docker/.autotesting/.stack
+      - SUPERVISOR_CHILD_LOG=/home/docker/.autotesting/supervisor_child_log
     depends_on:
       - postgres
       - redis

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,7 +17,7 @@ services:
       - SUPERVISOR_URL=127.0.0.1:9001
       - AUTOTESTER_CONFIG=/app/.dockerfiles/docker-config.yml
       - STACK_ROOT=/home/docker/.autotesting/.stack
-      - SUPERVISOR_CHILD_LOG=/home/docker/.autotesting/supervisor_child_log
+      - WORKER_LOG_DIR=/home/docker/.autotesting/worker_log_dir
     depends_on:
       - postgres
       - redis

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -7,3 +7,4 @@ autotest_server/testers/java/lib/
 __pycache__
 .DS_Store
 .hypothesis/
+supervisor_child_log/

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -7,4 +7,3 @@ autotest_server/testers/java/lib/
 __pycache__
 .DS_Store
 .hypothesis/
-supervisor_child_log/

--- a/server/autotest_server/settings.yml
+++ b/server/autotest_server/settings.yml
@@ -1,7 +1,7 @@
 workspace: !ENV ${WORKSPACE}
 redis_url: !ENV ${REDIS_URL}
 supervisor_url: !ENV ${SUPERVISOR_URL}
-supervisor_child_log: !ENV ${SUPERVISOR_CHILD_LOG}
+worker_log_dir: !ENV ${WORKER_LOG_DIR}
 workers:
   - user: !ENV ${USER}
     queues:

--- a/server/autotest_server/settings.yml
+++ b/server/autotest_server/settings.yml
@@ -1,6 +1,7 @@
 workspace: !ENV ${WORKSPACE}
 redis_url: !ENV ${REDIS_URL}
 supervisor_url: !ENV ${SUPERVISOR_URL}
+supervisor_child_log: !ENV ${SUPERVISOR_CHILD_LOG}
 workers:
   - user: !ENV ${USER}
     queues:

--- a/server/install.py
+++ b/server/install.py
@@ -62,9 +62,9 @@ def create_workspace():
     os.makedirs(config["workspace"], exist_ok=True)
 
 
-def create_supervisor_child_log():
-    _print(f'creating supervisor log folder for its children at {config["supervisor_child_log"]}')
-    os.makedirs(config["supervisor_child_log"], exist_ok=True)
+def create_worker_log_dir():
+    _print(f'creating worker log directory at {config["worker_log_dir"]}')
+    os.makedirs(config["worker_log_dir"], exist_ok=True)
 
 
 def install_all_testers():
@@ -81,7 +81,7 @@ def install():
     check_dependencies()
     check_users_exist()
     create_workspace()
-    create_supervisor_child_log()
+    create_worker_log_dir()
     install_all_testers()
 
 

--- a/server/install.py
+++ b/server/install.py
@@ -62,6 +62,11 @@ def create_workspace():
     os.makedirs(config["workspace"], exist_ok=True)
 
 
+def create_supervisor_child_log():
+    _print(f'creating supervisor log folder for its children at {config["supervisor_child_log"]}')
+    os.makedirs(config["supervisor_child_log"], exist_ok=True)
+
+
 def install_all_testers():
     settings = install_testers()
     skeleton_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "autotest_server", "schema_skeleton.json")
@@ -76,6 +81,7 @@ def install():
     check_dependencies()
     check_users_exist()
     create_workspace()
+    create_supervisor_child_log()
     install_all_testers()
 
 

--- a/server/start_stop.py
+++ b/server/start_stop.py
@@ -40,6 +40,12 @@ autostart=true
 autorestart=true
 stopasgroup=true
 killasgroup=true
+stdout_logfile={stdout_logfile}
+stdout_logfile_maxbytes=1MB
+stdout_logfile_backups=10
+stderr_logfile={stderr_logfile}
+stderr_logfile_maxbytes=1MB
+stderr_logfile_backups=10
 
 """
 
@@ -57,6 +63,8 @@ def create_enqueuer_wrapper(rq):
                 queues=" ".join(worker_data["queues"]),
                 numprocs=1,
                 directory=os.path.dirname(os.path.realpath(__file__)),
+                stdout_logfile=os.path.join(_THIS_DIR, f'supervisor_child_log/{worker_data["user"]}_stdout.log'),
+                stderr_logfile=os.path.join(_THIS_DIR, f'supervisor_child_log/{worker_data["user"]}_stderr.log'),
             )
             f.write(c)
 

--- a/server/start_stop.py
+++ b/server/start_stop.py
@@ -63,8 +63,12 @@ def create_enqueuer_wrapper(rq):
                 queues=" ".join(worker_data["queues"]),
                 numprocs=1,
                 directory=os.path.dirname(os.path.realpath(__file__)),
-                stdout_logfile=os.path.join(_THIS_DIR, f'supervisor_child_log/{worker_data["user"]}_stdout.log'),
-                stderr_logfile=os.path.join(_THIS_DIR, f'supervisor_child_log/{worker_data["user"]}_stderr.log'),
+                stdout_logfile=os.path.join(
+                    _THIS_DIR, f'{config["supervisor_child_log"]}/{worker_data["user"]}_stdout.log'
+                ),
+                stderr_logfile=os.path.join(
+                    _THIS_DIR, f'{config["supervisor_child_log"]}/{worker_data["user"]}_stderr.log'
+                ),
             )
             f.write(c)
 

--- a/server/start_stop.py
+++ b/server/start_stop.py
@@ -63,12 +63,8 @@ def create_enqueuer_wrapper(rq):
                 queues=" ".join(worker_data["queues"]),
                 numprocs=1,
                 directory=os.path.dirname(os.path.realpath(__file__)),
-                stdout_logfile=os.path.join(
-                    _THIS_DIR, f'{config["supervisor_child_log"]}/{worker_data["user"]}_stdout.log'
-                ),
-                stderr_logfile=os.path.join(
-                    _THIS_DIR, f'{config["supervisor_child_log"]}/{worker_data["user"]}_stderr.log'
-                ),
+                stdout_logfile=os.path.join(_THIS_DIR, f'{config["worker_log_dir"]}/{worker_data["user"]}_stdout.log'),
+                stderr_logfile=os.path.join(_THIS_DIR, f'{config["worker_log_dir"]}/{worker_data["user"]}_stderr.log'),
             )
             f.write(c)
 


### PR DESCRIPTION
**Description:**

We want to have logging for supervisor's child process logs for both stderr and stdout.  These logs will be stored under the folder `supervisor_child_log`. I have set the log file rotation to a file size of 1MB with 10 backups. e.g.:

```
stdout_logfile_maxbytes=1MB
stdout_logfile_backups=10
stderr_logfile_maxbytes=1MB
stderr_logfile_backups=10
```

Here is a screenshot of how it looks like on my local server's workspace docker volume in regards to the generated log files:
<img width="564" alt="Screenshot 2025-02-24 at 12 52 48 PM" src="https://github.com/user-attachments/assets/3cb3e8c6-4aaa-4754-a548-fefab5151b51" />


