### PR TITLE
Update "setting up test environment" message with http response

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented here.
 - Update python, pyta and jupyter testers to allow a requirements file (#580)
 - Update R tester to allow a renv.lock file (#581)
 - Improve display of Python package installation errors when creating environment (#585)
-- Update "setting up test environment" message with http response (#589)
+- Update "setting up test environment" message with http response of status code 503 (#589)
 
 ## [v2.6.0]
 - Update python versions in docker file (#568)

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented here.
 - Update python, pyta and jupyter testers to allow a requirements file (#580)
 - Update R tester to allow a renv.lock file (#581)
 - Improve display of Python package installation errors when creating environment (#585)
-- Change rlimit resource settings to apply each worker individually (#587)
 - Update "setting up test environment" message with http response of status code 503 (#589)
+- Change rlimit resource settings to apply each worker individually (#587) 
 
 ## [v2.6.0]
 - Update python versions in docker file (#568)

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented here.
 - Update python, pyta and jupyter testers to allow a requirements file (#580)
 - Update R tester to allow a renv.lock file (#581)
 - Improve display of Python package installation errors when creating environment (#585)
+- Update "setting up test environment" message with http response (#589)
 
 ## [v2.6.0]
 - Update python versions in docker file (#568)

--- a/client/autotest_client/__init__.py
+++ b/client/autotest_client/__init__.py
@@ -224,7 +224,7 @@ def run_tests(settings_id, user):
     test_settings = json.loads(REDIS_CONNECTION.hget("autotest:settings", key=settings_id))
     env_status = test_settings.get("_env_status")
     if env_status == "setup":
-        raise Exception("Setting up test environment. Please try again later.")
+        abort(make_response(jsonify(message="Setting up test environment. Please try again later."), 503))
     elif env_status == "error":
         msg = "Settings Error"
         settings_error = test_settings.get("_error", "")


### PR DESCRIPTION
When the setting up of the test environment is still in progress, currently we would send an exception back to the MarkUs application to notify the user. However, we rather receive an http response instead of an exception, this way we can act accordingly with regards to the http response code. 

This PR needs to be deployed together with the MarkUs PR as they work hand in hand. 
MarkUs PR: https://github.com/MarkUsProject/Markus/pull/7445