### PR TITLE
Improve error reporting with handled assertion errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,6 @@ repos:
     hooks:
     - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.1.2
     hooks:
     - id: flake8

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented here.
 - Update python, pyta and jupyter testers to allow a requirements file (#580)
 - Update R tester to allow a renv.lock file (#581)
 - Improve display of Python package installation errors when creating environment (#585)
+- Improve error reporting with handled assertion errors (#591)
 
 ## [v2.6.0]
 - Update python versions in docker file (#568)

--- a/server/autotest_server/__init__.py
+++ b/server/autotest_server/__init__.py
@@ -15,6 +15,7 @@ import importlib
 import psycopg2
 import mimetypes
 import rq
+import traceback
 from typing import Optional, Dict, Union, List, Tuple, Callable, Type
 from types import TracebackType
 
@@ -312,7 +313,9 @@ def _setup_files(settings_id: int, user: str, files_url: str, tests_path: str, t
         else:
             os.chmod(file_or_dir, 0o770)
         shutil.chown(file_or_dir, group=test_username)
-    test_script_dir = json.loads(redis_connection().hget("autotest:settings", settings_id))["_files"]
+    settings = json.loads(redis_connection().hget("autotest:settings", settings_id))
+    assert "_files" in settings, "Required key `_files` not found in settings"
+    test_script_dir = settings["_files"]
     script_files = copy_tree(test_script_dir, tests_path)
     for fd, file_or_dir in script_files:
         if fd == "d":
@@ -362,8 +365,12 @@ def run_test(settings_id, test_id, files_url, categories, user, test_env_vars):
         finally:
             _stop_tester_processes(test_username)
             _clear_working_directory(tests_path, test_username)
-    except Exception as e:
-        error = str(e)
+    except AssertionError as e:
+        traceback.print_exc()
+        error = f"Failed to run tests: {e}"
+    except Exception:
+        traceback.print_exc()
+        error = traceback.format_exc()
     finally:
         key = f"autotest:test_result:{test_id}"
         redis_connection().set(key, json.dumps({"test_groups": results, "error": error}))


### PR DESCRIPTION
This PR improves error reporting by changing how tester exceptions are handled. Previously, caught exceptions were converted to strings before being added to the test result, which often produced unhelpful error messages (e.g., KeyError would report just the key itself).

This PR introduces a way to handle exceptions with user-friendly messages using assert. Developers are expected to assert conditions that, if violated, will cause the autotester to fail:

- Assertion errors are caught higher up, and the assertion error message (if provided) will be reported in the test result.
- For other types of exceptions, the full stack trace will be reported in the test result instead.

In both cases, the full stack trace is printed.