### PR TITLE
Stop the autotester from running tests if there are errors in test settings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented here.
 - Change rlimit resource settings to apply each worker individually (#587) 
 - Improve error reporting with handled assertion errors (#591)
 - Add custom pytest markers to Python tester to record MarkUs metadata (#592)
+- Stop the autotester from running tests if there are errors in test settings (#593) 
 
 ## [v2.6.0]
 - Update python versions in docker file (#568)

--- a/server/autotest_server/tests/test_autotest_server.py
+++ b/server/autotest_server/tests/test_autotest_server.py
@@ -5,6 +5,9 @@ import fakeredis
 import rq
 import autotest_server
 import os
+import unittest
+from unittest.mock import patch, MagicMock
+import json
 
 
 @pytest.fixture
@@ -103,3 +106,93 @@ def test_tmp_remove_other_user():
     subprocess.run(touch_cmd, shell=True)
     autotest_server._clear_working_directory(autotest_worker_working_dir, autotest_worker_remover)
     assert os.path.exists(path) is True
+
+
+class TestRunTest(unittest.TestCase):
+    @patch("autotest_server.redis_connection")
+    def test_error_in_settings(self, mock_redis):
+        """Test that run_test correctly handles settings with an '_error'
+        key and stores the appropriate error message in Redis.
+        """
+        mock_redis_instance = MagicMock()
+        mock_redis.return_value = mock_redis_instance
+
+        error_message = "Invalid configuration"
+        mock_settings = {"_error": error_message}
+        mock_redis_instance.hget.return_value = json.dumps(mock_settings)
+
+        autotest_server.run_test(
+            settings_id="test_settings_id",
+            test_id="test_id_123",
+            files_url="http://example.com/files",
+            categories=[],
+            user="test_user",
+            test_env_vars={},
+        )
+
+        expected_result = {"test_groups": [], "error": f"Failed to run tests: Error in test settings: {error_message}"}
+        mock_redis_instance.set.assert_called_once()
+        call_args = mock_redis_instance.set.call_args[0]
+        self.assertEqual(call_args[0], "autotest:test_result:test_id_123")
+        self.assertEqual(json.loads(call_args[1]), expected_result)
+
+    @patch("autotest_server.redis_connection")
+    def test_env_status_error(self, mock_redis):
+        """
+        Test that run_test correctly handles settings with '_env_status' set
+        to 'error' and stores the appropriate error message in Redis."""
+        mock_redis_instance = MagicMock()
+        mock_redis.return_value = mock_redis_instance
+
+        mock_settings = {"_env_status": "error"}
+        mock_redis_instance.hget.return_value = json.dumps(mock_settings)
+
+        autotest_server.run_test(
+            settings_id="test_settings_id",
+            test_id="test_id_456",
+            files_url="http://example.com/files",
+            categories=["unit"],
+            user="test_user",
+            test_env_vars={},
+        )
+
+        expected_result = {"test_groups": [], "error": "Failed to run tests: Error in test settings"}
+        mock_redis_instance.set.assert_called_once()
+        call_args = mock_redis_instance.set.call_args[0]
+        self.assertEqual(call_args[0], "autotest:test_result:test_id_456")
+        self.assertEqual(json.loads(call_args[1]), expected_result)
+
+    @patch("autotest_server.redis_connection")
+    @patch("autotest_server.tester_user")
+    def test_general_exception(self, mock_tester_user, mock_redis):
+        """Test that run_test properly captures and stores traceback information
+        when an unexpected exception occurs during execution.
+        """
+        mock_redis_instance = MagicMock()
+        mock_redis.return_value = mock_redis_instance
+
+        mock_settings = {"key": "value"}
+        mock_redis_instance.hget.return_value = json.dumps(mock_settings)
+
+        # `tester_user` is a function that gets called after we assert that settings don't have an error.
+        # We add an exception to this call to check the correct error value in the result.
+        mock_tester_user.side_effect = Exception("Unexpected error")
+
+        autotest_server.run_test(
+            settings_id="test_settings_id",
+            test_id="test_id_789",
+            files_url="http://example.com/files",
+            categories=["unit"],
+            user="test_user",
+            test_env_vars={},
+        )
+
+        mock_redis_instance.set.assert_called_once()
+        call_args = mock_redis_instance.set.call_args[0]
+        self.assertEqual(call_args[0], "autotest:test_result:test_id_789")
+
+        result_dict = json.loads(call_args[1])
+        self.assertEqual(result_dict["test_groups"], [])
+        self.assertIsNotNone(result_dict["error"])
+        self.assertIn("Traceback", result_dict["error"])
+        self.assertIn("Unexpected error", result_dict["error"])


### PR DESCRIPTION
This pull request includes changes to improve settings error handling in the `server/autotest_server` module. The most important change is adding assertions to check for errors in test settings (this stop the autotester from running tests if there are errors in test settings.)

- Added assertions to check for errors in test settings and environment status before running tests.
- Modified the `update_test_settings` to move setting the `_files` key closer to where the value for `_files` in first created. 
- Added unit tests for `run_test` to ensure it handles settings errors.