### PR TITLE
Quote redis port mapping in compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -75,7 +75,7 @@ services:
     volumes:
       - redis_autotest:/data
     ports:
-      - 6379
+      - '6379:6379'
 
   rq_dashboard:
     image: eoranged/rq-dashboard


### PR DESCRIPTION
This pull request includes a small change to the `compose.yaml` file. The change updates the `ports` configuration for the `redis` service to explicitly map the container port `6379` to the host port `6379`. Without this change any connections coming from outside the docker container will be refused, making it impossible to interact with redis using external tools.