### PR TITLE
Added MarkUs metadata for test marks to Python tester

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented here.
 - Update Python and Jupyter test names to follow `[file] class.funcname` format (#605)
 - Update r tester test_name formatting and add r tester tests (#606)
 - Update R tester to support MarkUs metadata (#615)
+- Update Python tester to support MarkUs metadata for test-specific marks earned and marks total (#619)
 
 ## [v2.7.0]
 - Update python, pyta and jupyter testers to allow a requirements file (#580)


### PR DESCRIPTION
This PR builds on #592 to add two new custom pytest marks: `markus_marks_earned` and `markus_marks_total`, which allow the user to specify mark values for individual test cases.

This PR only affects the Python tester and the `pytest` runner (not `unittest`).