### PR TITLE
install stack with ghcup

### DIFF
--- a/server/.dockerfiles/Dockerfile
+++ b/server/.dockerfiles/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update -y && \
                        libharfbuzz-dev \
                        libfribidi-dev \
                        libxml2-dev \
+                       libnuma-dev \
                        r-base
 
 RUN useradd -ms /bin/bash $LOGIN_USER && \

--- a/server/autotest_server/testers/haskell/requirements.system
+++ b/server/autotest_server/testers/haskell/requirements.system
@@ -2,7 +2,9 @@
 
 if ! dpkg -l ghc cabal-install haskell-stack &> /dev/null; then
   apt-get -y update
-  DEBIAN_FRONTEND=noninteractive apt-get install -y -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' ghc cabal-install haskell-stack
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' ghc cabal-install
 fi
 
-stack update
+curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+/home/docker/.ghcup/bin/ghcup install stack latest
+

--- a/server/autotest_server/testers/haskell/setup.py
+++ b/server/autotest_server/testers/haskell/setup.py
@@ -5,6 +5,9 @@ import subprocess
 HASKELL_TEST_DEPS = ["tasty-discover", "tasty-quickcheck"]
 STACK_RESOLVER = "lts-16.17"
 
+home = os.getenv("HOME")
+os.environ["PATH"] = f"{home}/.cabal/bin:{home}/.ghcup/bin:" + os.environ["PATH"]
+
 
 def create_environment(_settings, _env_dir, default_env_dir):
     env_data = _settings.get("env_data", {})


### PR DESCRIPTION
We would like to install stack with ghcup. 

Current Issues:
- unsure why the `$PATH `is not being passed into subprocess.run for create_environment() in the Haskell setup file.
- Current code `os.environ["PATH"] = f"{home}/.cabal/bin:{home}/.ghcup/bin:" + os.environ["PATH"]` is intended to be applied to child processes but it is not. I tried passing it via the subprocess.run arg env= , but that was unsuccessful as well.
