### PR TITLE
installing HUnit

### DIFF
--- a/server/autotest_server/testers/haskell/setup.py
+++ b/server/autotest_server/testers/haskell/setup.py
@@ -2,7 +2,7 @@ import os
 import json
 import subprocess
 
-HASKELL_TEST_DEPS = ["tasty-discover", "tasty-quickcheck"]
+HASKELL_TEST_DEPS = ["tasty-discover", "tasty-quickcheck", "HUnit"]
 STACK_RESOLVER = "lts-16.17"
 
 


### PR DESCRIPTION
We would like to have HUnit library available for Haskell testers, which this PR implements.

Issue:
This PR successfully installs HUnit. However, when we try to run HUnit tests on MarkUs we see the following error:

```
Traceback (most recent call last):
  File "/app/autotest_server/testers/tester.py", line 326, in run_func_wrapper
    return run_func(self, *args, **kwargs)
  File "/app/autotest_server/testers/haskell/haskell_tester.py", line 140, in run
    results = self.run_haskell_tests()
  File "/app/autotest_server/testers/haskell/haskell_tester.py", line 131, in run_haskell_tests
    raise Exception(out.stderr)
Exception: Invalid option `--quickcheck-tests=0'

Usage: tmpe555wcmq [-p|--pattern PATTERN] [-t|--timeout DURATION] 
                   [-j|--num-threads NUMBER] [-q|--quiet] [--hide-successes] 
                   [--color never|always|auto] [--ansi-tricks ARG] [--stats ARG]
                   [-l|--list-tests] [-j|--num-threads NUMBER] [-q|--quiet] 
                   [--hide-successes] [--color never|always|auto] 
                   [--ansi-tricks ARG]


Invalid option `--quickcheck-tests=0'

Usage: tmpe555wcmq [-p|--pattern PATTERN] [-t|--timeout DURATION] 
                   [-j|--num-threads NUMBER] [-q|--quiet] [--hide-successes] 
                   [--color never|always|auto] [--ansi-tricks ARG] [--stats ARG]
                   [-l|--list-tests] [-j|--num-threads NUMBER] [-q|--quiet] 
                   [--hide-successes] [--color never|always|auto] 
                   [--ansi-tricks ARG]
```

Here is the image where this error is displayed:
<img width="1159" height="538" alt="Screenshot 2025-08-20 at 1 19 46 PM" src="https://github.com/user-attachments/assets/6aed99f2-50b9-4596-83d9-a159a2cf07e8" />

This tells me that our current autotester does not support HUnit. I found out in the past we tried installing Hunit, but because the Haskell tester doesn't support it, they were told they could use the custom tester to invoke Haskell and Hunit. They opted to convert their Hunit tests to use quickcheck instead.