### PR TITLE
Ensured R tester always displays test messages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented here.
 - Add `ai_tester` module to support AI-based autograding via `ai-autograding-feedback` (#625)
 - Add `ai` to list of testers (#628)
 - Fixed an `AttributeError` when handling exceptions in server `update_test_settings` (#629)
+- Modified R tester to always display test result messages, even when tests pass (#633)
 
 ## [v2.7.0]
 - Update python, pyta and jupyter testers to allow a requirements file (#580)

--- a/server/autotest_server/testers/r/r_tester.py
+++ b/server/autotest_server/testers/r/r_tester.py
@@ -55,8 +55,7 @@ class RTest(Test):
             if result["type"] == "metadata":
                 continue
 
-            # Only add message if not a success, as testthat reports failure messages only
-            if result["type"] != "expectation_success":
+            if result.get("message"):
                 messages.append(result["message"])
 
             if result["type"] == "expectation_success":


### PR DESCRIPTION
Previously, the R tester only displays test messages when the test is not a success. Because test successes may also have messages, I've modified the tester to always include messages when they are present.