### PR TITLE
Haskell tester updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented here.
 ## [unreleased]
 
 - Update Haskell tester to report installation errors (#636)
+- Update Haskell tester test name formatting (#636)
 
 ## [v2.8.0]
 - Update Python and Jupyter test names to follow `[file] class.funcname` format (#605)

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented here.
 
 - Update Haskell tester to report installation errors (#636)
 - Update Haskell tester test name formatting (#636)
+- Update Haskell tester to support `tasty-hunit` adapter (#636)
 
 ## [v2.8.0]
 - Update Python and Jupyter test names to follow `[file] class.funcname` format (#605)

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 
+- Update Haskell tester to report installation errors (#636)
+
 ## [v2.8.0]
 - Update Python and Jupyter test names to follow `[file] class.funcname` format (#605)
 - Update r tester test_name formatting and add r tester tests (#606)

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Both the autotester and the API are designed to be run on Ubuntu 20.04 (or suffi
 The autotester currently supports testers for the following languages and testing frameworks:
 
 - `haskell`
-    - [QuickCheck](http://hackage.haskell.org/package/QuickCheck)
+    - [`tasty-hunit`](https://hackage.haskell.org/package/tasty-hunit)
+    - [`tasty-quickcheck`](https://hackage.haskell.org/package/tasty-quickcheck)
 - `java`
     - [JUnit](https://junit.org/junit4/)
 - `py` (python3)
@@ -149,8 +150,8 @@ Installing each tester will also install the following additional packages (syst
     - ghc 
     - cabal-install 
     - haskell-stack
-    - tasty-stats (cabal package)
     - tasty-discover (cabal package)
+    - tasty-hunit (cabal package)
     - tasty-quickcheck (cabal package)
 - `java`
     - openjdk-8-jdk

--- a/server/autotest_server/testers/haskell/haskell_tester.py
+++ b/server/autotest_server/testers/haskell/haskell_tester.py
@@ -73,8 +73,11 @@ class HaskellTester(Tester):
             module_flag,
             stats_flag,
             f"--timeout={self.specs['test_data', 'test_timeout']}s",
-            f"--quickcheck-tests={self.specs['test_data', 'test_cases']}",
         ]
+        test_cases = self.specs["test_data", "test_cases"] or 0
+        if test_cases > 0:
+            flags.append(f"--quickcheck-tests={test_cases}")
+
         return flags
 
     def _parse_test_results(self, reader: Iterator) -> List[Dict[str, Union[int, str]]]:

--- a/server/autotest_server/testers/haskell/haskell_tester.py
+++ b/server/autotest_server/testers/haskell/haskell_tester.py
@@ -30,8 +30,9 @@ class HaskellTest(Test):
     def test_name(self) -> str:
         """The name of this test"""
         if self._test_name:
-            return ".".join([self._file_name, self._test_name])
-        return self._file_name
+            return f"[{self._file_name}] {self._test_name}"
+        else:
+            return f"[{self._file_name}]"
 
     @Test.run_decorator
     def run(self) -> str:

--- a/server/autotest_server/testers/haskell/setup.py
+++ b/server/autotest_server/testers/haskell/setup.py
@@ -2,7 +2,7 @@ import os
 import json
 import subprocess
 
-HASKELL_TEST_DEPS = ["tasty-discover", "tasty-quickcheck"]
+HASKELL_TEST_DEPS = ["tasty-discover", "tasty-quickcheck", "tasty-hunit"]
 STACK_RESOLVER = "lts-16.17"
 
 

--- a/server/autotest_server/testers/haskell/setup.py
+++ b/server/autotest_server/testers/haskell/setup.py
@@ -10,18 +10,27 @@ def create_environment(_settings, _env_dir, default_env_dir):
     env_data = _settings.get("env_data", {})
     resolver = env_data.get("resolver_version", STACK_RESOLVER)
     cmd = ["stack", "build", "--resolver", resolver, "--system-ghc", *HASKELL_TEST_DEPS]
-    subprocess.run(cmd, check=True)
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
 
     return {"PYTHON": os.path.join(default_env_dir, "bin", "python3")}
 
 
 def install():
-    subprocess.run(os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.system"), check=True)
+    subprocess.run(
+        os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.system"),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
     resolver = STACK_RESOLVER
     cmd = ["stack", "build", "--resolver", resolver, "--system-ghc", *HASKELL_TEST_DEPS]
-    subprocess.run(cmd, check=True)
+    subprocess.run(cmd, check=True, capture_output=True)
     subprocess.run(
-        os.path.join(os.path.dirname(os.path.realpath(__file__)), "stack_permissions.sh"), check=True, shell=True
+        os.path.join(os.path.dirname(os.path.realpath(__file__)), "stack_permissions.sh"),
+        check=True,
+        shell=True,
+        capture_output=True,
+        text=True,
     )
 
 


### PR DESCRIPTION
This PR makes three updates to the Haskell tester:

1. Report (stderr) error messages from installation `subprocess.run` calls
2. Improve separation of filename and test name
3. Add support for [`tasty-hunit`](https://hackage.haskell.org/package/tasty-hunit)