### PR TITLE
Disabled access to third-party models in AI tester

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 - Changed tasty-discover argument of source directory to a file (#648)
+- Disabled access to third-party models in AI tester (#649)
 
 ## [v2.8.1]
 - Update Haskell tester to report installation errors (#636)

--- a/server/autotest_server/testers/ai/ai_tester.py
+++ b/server/autotest_server/testers/ai/ai_tester.py
@@ -72,6 +72,15 @@ class AiTester(Tester):
         output_mode = test_group.get("output")
         cmd = [sys.executable, "-m", "ai_feedback"]
 
+        # Temporarily disable non-local models
+        if config.get("model", "") != "remote":
+            results[test_label] = {
+                "title": test_label,
+                "status": "error",
+                "message": f"Unsupported model type: \"{config.get('model', '')}\"",
+            }
+            return results
+
         submission_file = config.get("submission")
         if self._term_in_file(submission_file):
             results[test_label] = {

--- a/server/autotest_server/tests/testers/ai/test_ai_tester.py
+++ b/server/autotest_server/tests/testers/ai/test_ai_tester.py
@@ -29,7 +29,7 @@ def create_ai_tester():
         "test_data": {
             "category": ["instructor"],
             "config": {
-                "model": "openai",
+                "model": "remote",
                 "prompt": "code_table",
                 "scope": "code",
                 "submission": parent_dir + "/fixtures/sample_submission.py",


### PR DESCRIPTION
This PR checks the `model` argument in the AI tester and allows only the remote (local) model to be used.