### PR TITLE
Fixed Python tester to display fully qulaified name when running pytest

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented here.
 ## [unreleased]
 - Install stack with GHCup (#626)
 - Add troubleshooting section talking about Docker Content Trust (DCT) (#653)
+- Fixed Python tester to display fully qualified name when running pytest (#656)
 
 ## [v2.8.2]
 - Changed tasty-discover argument of source directory to a file (#648)

--- a/server/autotest_server/testers/py/py_tester.py
+++ b/server/autotest_server/testers/py/py_tester.py
@@ -196,7 +196,7 @@ class PytestPlugin:
 
     def _format_test_name(self, report):
         parts = report.nodeid.split("::")
-        return f"[{parts[0]}] {parts[-1]}" if len(parts) > 1 else f"[{parts[0]}]"
+        return f"[{parts[0]}] {'.'.join(parts[1:])}" if len(parts) > 1 else f"[{parts[0]}]"
 
 
 class PyTest(Test):


### PR DESCRIPTION
This fixes a bug where previously the pytest test runner only displayed the function name for a test written inside a class. It now displays the fully qualified name, e.g. `TestClass.test_method` rather than just `test_method`.