### PR TITLE
Fixed AI tester to report error when the specified submission file is not found

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 - Install stack with GHCup (#626)
+- Fixed AI tester to report error when the specified `submission` file is not found (#663)
 
 ## [v2.8.3]
 - Add troubleshooting section talking about Docker Content Trust (DCT) (#653)


### PR DESCRIPTION
Previously, when the submission file wasn't found, the AI tester reported `"Student included the text 'NO_EXTERNAL_AI_FEEDBACK' in their submission file. No AI feedback generated."`

This was due to the implementation of the `AITester._term_in_file` method, which returned `True` when the file was not found. I modified the implementation to raise a `FileNotFoundError` instead.