### PR TITLE
Add missing Dockerfile dependencies

### DIFF
--- a/server/.dockerfiles/Dockerfile
+++ b/server/.dockerfiles/Dockerfile
@@ -30,7 +30,11 @@ RUN apt-get update -y && \
                        libfribidi-dev \
                        libxml2-dev \
                        libnuma-dev \
-                       r-base
+                       r-base \
+                       curl \
+                       ghc \
+                       cabal-install \ 
+                       haskell-stack
 
 RUN useradd -ms /bin/bash $LOGIN_USER && \
     usermod -aG sudo $LOGIN_USER && \


### PR DESCRIPTION
## Description

During the autotest set up [process](https://github.com/MarkUsProject/Wiki/blob/master/Developer-Guide--Set-Up-With-Docker.md#setting-up-the-autotester), the following error kept appearing when running `docker compose up`: 

```
server-1 | Exception: haskell install failed with: Command '/app/autotest_server/testers/haskell/requirements.system' 
returned non-zero exit status 127.
```

After some investigation, it was discovered that the following [packages](https://github.com/MarkUsProject/markus-autotesting/blob/master/server/autotest_server/testers/haskell/requirements.system#L6) were failing to install due to permission errors. 

## Implementation

Install required dependencies during image creation and bypass user permissions.


