### PR TITLE
Updated docker to Ubuntu 24.04 and fixed stack installation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented here.
 ## [unreleased]
 - Install stack with GHCup (#626)
 - Fixed AI tester to report error when the specified `submission` file is not found (#663)
+- Updated docker image to use Ubuntu 24.04 (#668)
+- Fixed stack installation in Docker environment (#668)
 
 ## [v2.8.3]
 - Add troubleshooting section talking about Docker Content Trust (DCT) (#653)

--- a/client/.dockerfiles/Dockerfile
+++ b/client/.dockerfiles/Dockerfile
@@ -1,6 +1,9 @@
-ARG UBUNTU_VERSION=22.04
+ARG UBUNTU_VERSION=24.04
 
 FROM ubuntu:$UBUNTU_VERSION
+
+# Remove ubuntu user, added in the 23.04 image
+RUN userdel -r ubuntu
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install software-properties-common && \

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,10 +4,10 @@ services:
       context: ./server
       dockerfile: ./.dockerfiles/Dockerfile
       args:
-        UBUNTU_VERSION: '22.04'
+        UBUNTU_VERSION: '24.04'
         LOGIN_USER: 'docker'
         WORKSPACE: '/home/docker/.autotesting'
-    image: markus-autotest-server-dev:1.3.0
+    image: markus-autotest-server-dev:1.4.0
     volumes:
       - ./server:/app:cached
       - venv_server:/home/docker/markus_venv
@@ -28,8 +28,8 @@ services:
       context: ./client
       dockerfile: ./.dockerfiles/Dockerfile
       args:
-        UBUNTU_VERSION: '22.04'
-    image: markus-autotest-client-dev:1.3.0
+        UBUNTU_VERSION: '24.04'
+    image: markus-autotest-client-dev:1.4.0
     container_name: 'autotest-client'
     volumes:
       - ./client:/app:cached

--- a/server/.dockerfiles/Dockerfile
+++ b/server/.dockerfiles/Dockerfile
@@ -1,7 +1,9 @@
-ARG UBUNTU_VERSION=22.04
+ARG UBUNTU_VERSION=24.04
 
 FROM ubuntu:$UBUNTU_VERSION AS base
 
+# Remove ubuntu user, added in the 23.04 image
+RUN userdel -r ubuntu
 
 ARG LOGIN_USER
 ARG WORKSPACE
@@ -38,9 +40,8 @@ RUN useradd -ms /bin/bash $LOGIN_USER && \
         adduser --disabled-login --no-create-home $worker && \
         echo "$LOGIN_USER ALL=($worker) NOPASSWD:ALL" | EDITOR="tee -a" visudo && \
         usermod -aG $worker $LOGIN_USER; \
-    done
-
-RUN chmod a+x /home/${LOGIN_USER}
+    done && \
+    chmod a+x /home/${LOGIN_USER}
 
 COPY . /app
 
@@ -48,8 +49,8 @@ RUN find /app/autotest_server/testers -name requirements.system -exec {} \;
 
 RUN echo "TZ=$( cat /etc/timezone )" >> /etc/R/Renviron.site
 
-RUN mkdir -p ${WORKSPACE} && chown ${LOGIN_USER} ${WORKSPACE}
-RUN mkdir -p /home/${LOGIN_USER}/markus_venv && chown ${LOGIN_USER} /home/${LOGIN_USER}/markus_venv
+RUN mkdir -p ${WORKSPACE} && chown ${LOGIN_USER} ${WORKSPACE} && \
+    mkdir -p /home/${LOGIN_USER}/markus_venv && chown ${LOGIN_USER} /home/${LOGIN_USER}/markus_venv
 
 WORKDIR /home/${LOGIN_USER}
 

--- a/server/autotest_server/testers/haskell/requirements.system
+++ b/server/autotest_server/testers/haskell/requirements.system
@@ -6,7 +6,10 @@ if ! dpkg -l ghc cabal-install &> /dev/null; then
   DEBIAN_FRONTEND=noninteractive apt-get install -y -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' ghc cabal-install
 fi
 
-if [ ! -x "$HOME/.ghcup/bin/ghcup" ]; then
-  curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+if [ ! -x "$HOME/.ghcup/bin/ghcup" ] && [ ! -x "/usr/local/bin/stack" ]; then
+  BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
   $HOME/.ghcup/bin/ghcup install stack recommended
+  if [ "$(id -u)" -eq 0 ]; then
+    cp $HOME/.ghcup/bin/stack /usr/local/bin/
+  fi
 fi

--- a/server/autotest_server/testers/haskell/setup.py
+++ b/server/autotest_server/testers/haskell/setup.py
@@ -3,7 +3,7 @@ import json
 import subprocess
 
 HASKELL_TEST_DEPS = ["tasty-discover", "tasty-quickcheck", "tasty-hunit"]
-STACK_RESOLVER = "lts-16.17"
+STACK_RESOLVER = "lts-21.21"
 
 home = os.getenv("HOME")
 os.environ["PATH"] = f"{home}/.cabal/bin:{home}/.ghcup/bin:" + os.environ["PATH"]
@@ -19,22 +19,31 @@ def create_environment(_settings, _env_dir, default_env_dir):
 
 
 def install():
-    subprocess.run(
-        os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.system"),
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        subprocess.run(
+            os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.system"),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Error executing Haskell requirements.system: {e}")
     resolver = STACK_RESOLVER
     cmd = ["stack", "build", "--resolver", resolver, "--system-ghc", *HASKELL_TEST_DEPS]
-    subprocess.run(cmd, check=True, capture_output=True)
-    subprocess.run(
-        os.path.join(os.path.dirname(os.path.realpath(__file__)), "stack_permissions.sh"),
-        check=True,
-        shell=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        subprocess.run(cmd, check=True, capture_output=True)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Error running {cmd}: {e}")
+    try:
+        subprocess.run(
+            os.path.join(os.path.dirname(os.path.realpath(__file__)), "stack_permissions.sh"),
+            check=True,
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Error running Haskell stack_permissions.sh: {e}")
 
 
 def settings():


### PR DESCRIPTION
This PR makes two updates relating to (re)building the Docker images.

1. Update the development docker configuration to use Ubuntu 24.04 (up from 22.04).
2. Fixed the Haskell stack installation using ghcup. There were two issues: (1) invoking the ghcup installation script needed to be done in non-interactive mode; and (2) `stack` was being installed in the root home folder (`/home/root/.ghcup`) but was not available to other users. 