### PR TITLE
Removed click from server requirements.txt file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented here.
 - Fixed AI tester to report error when the specified `submission` file is not found (#663)
 - Updated docker image to use Ubuntu 24.04 (#668)
 - Fixed stack installation in Docker environment (#668)
+- Removed `click` from server requirements.txt file (#679)
 
 ## [v2.8.3]
 - Add troubleshooting section talking about Docker Content Trust (DCT) (#653)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,5 +1,4 @@
 rq==2.6.0
-click==8.1.8
 redis==6.4.0
 pyyaml==6.0.3
 jsonschema==4.25.1


### PR DESCRIPTION
This PR removes the explicit `click` dependency from the server `requirements.txt` file. The autotest server doesn't use this dependency explicitly; it was previously limited to `click < 8.0` when rq didn't support click v8.0, but this was fixed [four years ago](https://github.com/rq/rq/releases/tag/v1.8.1).