### PR TITLE
Fixed bug in R tester setup that always triggered reinstallation of R dependencies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented here.
 - Updated docker image to use Ubuntu 24.04 (#668)
 - Fixed stack installation in Docker environment (#668)
 - Removed `click` from server requirements.txt file (#679)
+- Fixed bug in R tester setup that always triggered reinstallation of R dependencies (#680)
 
 ## [v2.8.3]
 - Add troubleshooting section talking about Docker Content Trust (DCT) (#653)

--- a/server/autotest_server/testers/r/lib/r_tester_setup.R
+++ b/server/autotest_server/testers/r/lib/r_tester_setup.R
@@ -38,7 +38,7 @@ install_dep <- function(row) {
   } else {
     remote_type <- NA_character_
   }
-  if (!('stringi' %in% rownames(installed.packages))) {
+  if (!('stringi' %in% rownames(installed.packages()))) {
     install.packages(name, configure.args="--disable-pkg-config")
   }
 


### PR DESCRIPTION
In the R script `r_tester_setup.R`, the `install_dep` function was intended to first check whether packages (and `stringi` in particular) were already installed before triggering a re-install. However, one of these checks used `installed.packages` instead of `installed.packages()`, where the latter is required to actually retrieve the list of installed packages, and so the check was always failing.