### PR TITLE
Fixed Haskell test results to only include the function name

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented here.
 
 ## [unreleased]
+- Fixed Haskell test results to only include the function name (#687)
 
 ## [v2.9.0]
 - Install stack with GHCup (#626)

--- a/server/autotest_server/testers/haskell/lib/Stats.hs
+++ b/server/autotest_server/testers/haskell/lib/Stats.hs
@@ -85,4 +85,10 @@ resultRow results = do
     \(show -> idx, (name, Result { resultDescription=dropWhileEnd isSpace -> description
                                  , resultShortDescription=result
                                  , resultTime=show -> time })) ->
-    [idx, name, time, result, description]
+    [ idx
+      -- Extract the property name from the TestName. Tasty uses '.' to join module and test name.
+    , reverse $ takeWhile (/= '.') $ reverse name
+    , time
+    , result
+    , description
+    ]


### PR DESCRIPTION
Previously the Haskell tester reported a qualified path and module name for each Haskell test. This was a result of how Tasty reports test names to our custom `Stats.hs` module. I fixed this by doing some post-processing of the test names, extracting the segment after the final `'.'` in the reported name.

Before:

<img width="1413" height="620" alt="image" src="https://github.com/user-attachments/assets/b61e2d97-aa51-42ec-a88a-bb4e7d6f81be" />

After:

<img width="1169" height="621" alt="image" src="https://github.com/user-attachments/assets/c576d1ce-e06b-47b2-955a-eeb265842eec" />
