### PR TITLE
Resolve ghcup isolation installation failure in Haskell autotester

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented here.
 - Disable pytest cacheprovider to avoid creating .pytest_cache in isolated runs (#709)
 - Fixed Python tester to correctly report marks when `markus_marks_earned` equals total or zero (#716)
 - Fix worker orphan processes and add server-side max test timeout cap (#710)
+- Resolve ghcup isolation installation failure in Haskell autotester (#725)
 
 ## [v2.9.0]
 - Install stack with GHCup (#626)

--- a/server/autotest_server/testers/haskell/requirements.system
+++ b/server/autotest_server/testers/haskell/requirements.system
@@ -21,5 +21,13 @@ if [ ! -x "/usr/local/bin/stack" ]; then
     libgmp10 \
     libncurses-dev
   curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_MINIMAL=1 sh
-  $HOME/.ghcup/bin/ghcup install stack recommended --isolate /usr/local/bin
+
+  # Create a dedicated, empty folder to satisfy ghcup's isolation requirements
+  mkdir -p /usr/local/bin/stack-isolated
+
+  # Install stack cleanly into the isolated subfolder
+  ~/.ghcup/bin/ghcup install stack recommended --isolate /usr/local/bin/stack-isolated
+
+  # Link the executable back into the global PATH
+  ln -sf /usr/local/bin/stack-isolated/stack /usr/local/bin/stack
 fi


### PR DESCRIPTION
### Context
During the Docker container build and initialization phase, the Haskell toolchain installer (`ghcup`) was failing when executing `/app/autotest_server/testers/haskell/requirements.system`. This failure returned a non-zero exit code (`100`).

### Cause of the Issue
The script previously passed the `--isolate /usr/local/bin` flag to `ghcup`. However, `ghcup` includes a strict safety guard: it will refuse to unpack assets into an isolation target directory if that directory is not completely empty. Because modern base images (like `ubuntu:24.04`) pre-populate `/usr/local/bin` with standard system binaries and symlinks, `ghcup` aborted with a fatal error:
`[ Error ] Install directory /usr/local/bin is not empty.`

### Changes Implemented
1. **Isolated Sandboxing:** Updated `requirements.system` to create a dedicated, guaranteed-empty subdirectory: `/usr/local/bin/stack-isolated`.
2. **Global Symlinking:** Directed ghcup to extract stack cleanly into this empty directory, then created a system-wide symlink at /usr/local/bin/stack pointing to the isolated binary (/usr/local/bin/stack-isolated/stack). This satisfies ghcup's safety checks while keeping the binary universally accessible to the tester framework.
3. **Robust Home Expansion:** Swapped out the `$HOME` environment variable for shell tilde (`~`) expansion to ensure absolute home path resolution regardless of the active Docker build context.