### PR TITLE
Add libuv1-dev system dependency required by fs 2.x

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented here.
 - Fixed Python tester to correctly report marks when `markus_marks_earned` equals total or zero (#716)
 - Fix worker orphan processes and add server-side max test timeout cap (#710)
 - Resolve ghcup isolation installation failure in Haskell autotester (#725)
+- Add libuv1-dev system dependency required by fs 2.x (#732)
 
 ## [v2.9.0]
 - Install stack with GHCup (#626)

--- a/server/autotest_server/testers/r/requirements.system
+++ b/server/autotest_server/testers/r/requirements.system
@@ -8,7 +8,8 @@ if ! dpkg -l r-base &> /dev/null; then
   # Set global R timezone
   echo "TZ=$( cat /etc/timezone )" >> /etc/R/Renviron.site
 
-  # Install system requirements for tidyverse. Obtained by running `pak::pkg_system_requirements("tidyverse")`.
+  # Install system requirements for tidyverse and fs. Obtained by running `pak::pkg_system_requirements("tidyverse")`
+  # and adding libuv1-dev for the fs package (required since fs 2.x dropped its vendored libuv).
   DEBIAN_FRONTEND=noninteractive apt-get install -y -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' \
     libx11-dev \
     libcurl4-openssl-dev \
@@ -25,5 +26,6 @@ if ! dpkg -l r-base &> /dev/null; then
     libfontconfig1-dev \
     libfribidi-dev \
     libharfbuzz-dev \
-    libxml2-dev
+    libxml2-dev \
+    libuv1-dev
 fi


### PR DESCRIPTION
The `fs` R package 2.x dropped its vendored copy of `libuv` and now requires
a system `libuv` development library, discovered via `pkg-config` at build time.
Without `libuv1-dev` installed, creating an R tester environment fails.

Add `libuv1-dev` to the apt-get install block in the R tester setup script
alongside the other system dependencies.

**Test Setup**

**How fs is loaded**

```
testthat → pkgload → fs
```

The instructor test script is responsible for loading `testthat`. 

```r
# instructor test script
library(testthat)
```

**Verifying the setup**

After saving the autotest settings, run a test. If none of the following errors appear, the setup is working correctly:

```
Package libuv was not found in the pkg-config search path.
Package 'libuv', required by 'virtual:world', not found
ERROR: configuration failed for package 'fs'
```
