### PR TITLE
Fix output_verbosity Literal to accept int values for unittest tester

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented here.
 - Fix worker orphan processes and add server-side max test timeout cap (#710)
 - Resolve ghcup isolation installation failure in Haskell autotester (#725)
 - Add libuv1-dev system dependency required by fs 2.x (#732)
+- Fix output_verbosity Literal to accept int values for unittest tester (#733)
 
 ## [v2.9.0]
 - Install stack with GHCup (#626)

--- a/server/autotest_server/testers/py/schema.py
+++ b/server/autotest_server/testers/py/schema.py
@@ -30,5 +30,6 @@ class PyTestData(BaseTestData, kw_only=True):
 
     tester: Annotated[Literal["unittest", "pytest"], Meta(title="Test runner")] = "pytest"
     output_verbosity: Annotated[
-        Literal["", "short", "auto", "long", "no", "line", "native", 0, 1, 2], Meta(title="Output verbosity")
+        Literal["", "short", "auto", "long", "no", "line", "native"] | Literal[0, 1, 2],
+        Meta(title="Output verbosity"),
     ] = ""

--- a/server/autotest_server/testers/py/schema.py
+++ b/server/autotest_server/testers/py/schema.py
@@ -30,5 +30,5 @@ class PyTestData(BaseTestData, kw_only=True):
 
     tester: Annotated[Literal["unittest", "pytest"], Meta(title="Test runner")] = "pytest"
     output_verbosity: Annotated[
-        Literal["", "0", "1", "2", "short", "auto", "long", "no", "line", "native"], Meta(title="Output verbosity")
+        Literal["", "short", "auto", "long", "no", "line", "native", 0, 1, 2], Meta(title="Output verbosity")
     ] = ""

--- a/server/autotest_server/testers/py/setup.py
+++ b/server/autotest_server/testers/py/setup.py
@@ -25,20 +25,12 @@ def create_environment(settings_, env_dir, _default_env_dir):
 def settings():
     json_schema, components = generate_schema(PyTesterSettings)
 
-    # Modify output_verbosity enum manually. msgspec does not support JSON schema generation for
-    # Literal type annotations that contain multiple types.
-    components["PyTestData"]["properties"]["output_verbosity"]["enum"] = [
-        "",
-        0,
-        1,
-        2,
-        "auto",
-        "line",
-        "long",
-        "native",
-        "no",
-        "short",
-    ]
+    # output_verbosity is a union of two same-typed Literals (str set | int set),
+    # so msgspec emits it as anyOf of two enums. Flatten into a single enum for the
+    # JSON Schema form, which expects a flat dropdown rather than an anyOf selector.
+    prop = components["PyTestData"]["properties"]["output_verbosity"]
+    if "anyOf" in prop:
+        prop["enum"] = [v for sub in prop.pop("anyOf") for v in sub["enum"]]
 
     # Inject dependencies for output_verbosity for JSON Schema form
     json_schema["properties"]["test_data"]["items"]["dependencies"] = {

--- a/server/autotest_server/tests/testers/py/test_py_schema.py
+++ b/server/autotest_server/tests/testers/py/test_py_schema.py
@@ -1,4 +1,5 @@
 import msgspec
+import pytest
 
 from ....testers.py.schema import PyTesterSettings
 
@@ -49,3 +50,45 @@ def test_output_verbosity_accepts_string_for_pytest() -> None:
     verbosity = settings.test_data[0].output_verbosity
     assert verbosity == "short"
     assert type(verbosity) is str
+
+
+def test_output_verbosity_rejects_unknown_int() -> None:
+    """Integer values outside the allowed set must be rejected, not silently accepted."""
+    with pytest.raises(msgspec.ValidationError):
+        msgspec.json.decode(
+            b"""
+            {
+              "env_data": {},
+              "test_data": [
+                {
+                  "script_files": ["test.py"],
+                  "category": ["instructor"],
+                  "tester": "unittest",
+                  "output_verbosity": 5
+                }
+              ]
+            }
+            """,
+            type=PyTesterSettings,
+        )
+
+
+def test_output_verbosity_rejects_unknown_string() -> None:
+    """String values outside the allowed set must be rejected, not silently accepted."""
+    with pytest.raises(msgspec.ValidationError):
+        msgspec.json.decode(
+            b"""
+            {
+              "env_data": {},
+              "test_data": [
+                {
+                  "script_files": ["test.py"],
+                  "category": ["instructor"],
+                  "tester": "pytest",
+                  "output_verbosity": "verbose"
+                }
+              ]
+            }
+            """,
+            type=PyTesterSettings,
+        )

--- a/server/autotest_server/tests/testers/py/test_py_schema.py
+++ b/server/autotest_server/tests/testers/py/test_py_schema.py
@@ -1,0 +1,51 @@
+import msgspec
+
+from ....testers.py.schema import PyTesterSettings
+
+
+def test_output_verbosity_accepts_int_for_unittest() -> None:
+    """The MarkUs form emits integer verbosity (0/1/2) for unittest groups,
+    so the schema must decode an int without coercing it to a string."""
+    settings = msgspec.json.decode(
+        b"""
+        {
+          "env_data": {},
+          "test_data": [
+            {
+              "script_files": ["test.py"],
+              "category": ["instructor"],
+              "tester": "unittest",
+              "output_verbosity": 2
+            }
+          ]
+        }
+        """,
+        type=PyTesterSettings,
+    )
+    verbosity = settings.test_data[0].output_verbosity
+    assert verbosity == 2
+    assert type(verbosity) is int
+
+
+def test_output_verbosity_accepts_string_for_pytest() -> None:
+    """The MarkUs form emits string traceback styles for pytest groups,
+    so the schema must decode a string without coercing it to an int."""
+    settings = msgspec.json.decode(
+        b"""
+        {
+          "env_data": {},
+          "test_data": [
+            {
+              "script_files": ["test.py"],
+              "category": ["instructor"],
+              "tester": "pytest",
+              "output_verbosity": "short"
+            }
+          ]
+        }
+        """,
+        type=PyTesterSettings,
+    )
+    verbosity = settings.test_data[0].output_verbosity
+    assert verbosity == "short"
+    assert type(verbosity) is str


### PR DESCRIPTION
**Problem**

`output_verbosity` in `PyTestData` (shared by the pytest and unittest testers) was typed as a string-only `Literal`. The unittest tester uses integer verbosity levels (0/1/2, matching Python's `unittest`), and the MarkUs form already emits these ints — the manually patched JSON Schema enum allowed them. But the Struct type did not, so msgspec would reject an int-valued `output_verbosity` on decode.

We don't currently decode tester configs with msgspec (we read them as plain dicts), so nothing is breaking today. This aligns the type with the data and the already-patched schema so we're ready if/when we adopt msgspec decoding.

**Fix**

Adding the ints as a single mixed `Literal[..., 0, 1, 2]` isn't viable: `msgspec.json.schema_components` sorts Literal values to build the enum, and sorting mixed `int/str` raises `TypeError: '<' not supported between instances of 'int' and 'str'`, breaking schema generation. So `output_verbosity` is now a union of two same-typed Literals:

`pythonLiteral["", "short", "auto", "long", "no", "line", "native"] | Literal[0, 1, 2]`

msgspec emits this as an `anyOf` of two enums. In `settings()`, the old hardcoded enum patch is replaced with a step that flattens that `anyOf` into a single flat `enum`, which is the shape the form (rjsf) expects. The allowed values now live in the type and drive both validation and the generated schema, rather than a separately maintained hardcoded list.
