### PR TITLE
Added localhost:3000 forwarding to server Docker container

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented here.
 - Resolve ghcup isolation installation failure in Haskell autotester (#725)
 - Add libuv1-dev system dependency required by fs 2.x (#732)
 - Fix output_verbosity Literal to accept int values for unittest tester (#733)
+- Added `localhost:3000` forwarding to `server` Docker container (#740)
 
 ## [v2.9.0]
 - Install stack with GHCup (#626)

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,6 +22,9 @@ services:
     depends_on:
       - postgres
       - redis
+    networks:
+      - default
+      - markus_dev
 
   client: &client
     build:

--- a/server/.dockerfiles/Dockerfile
+++ b/server/.dockerfiles/Dockerfile
@@ -24,7 +24,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
                        postgresql-client \
                        libpq-dev \
                        sudo \
-                       git
+                       git \
+                       socat
 
 RUN useradd -ms /bin/bash $LOGIN_USER && \
     usermod -aG sudo $LOGIN_USER && \

--- a/server/.dockerfiles/cmd-dev.sh
+++ b/server/.dockerfiles/cmd-dev.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 
+# Forward localhost:3000 to the rails container, so that MarkUs URLs captured from browser
+# requests (which use localhost) resolve correctly when this container calls back into MarkUs.
+socat TCP-LISTEN:3000,fork,reuseaddr TCP:rails:3000 &
+
 markus_venv/bin/python /app/install.py
 markus_venv/bin/python /app/start_stop.py start -n


### PR DESCRIPTION
This PR uses [`socat`](https://linux.die.net/man/1/socat) in the `server` Docker container to forward requests to `localhost:3000` to `rails:3000`, which (on the `markus_dev` network) is the address of the running MarkUs server.

This will allow developers to run MarkUs autotesting when visiting the website with `localhost:3000` instead of requiring the use of `host.docker.internal:3000`.